### PR TITLE
feat: Allow name copied from iconify website to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To embed an icon, use the `{{< iconify >}}` shortcode[^1]. For example:
 
 ```default
 {{< iconify exploding-head >}}
+{{< iconify fluent-emoji exploding-head >}}
+{{< iconify fluent-emoji:exploding-head >}}
 {{< iconify exploding-head size=2xl >}}
 {{< iconify exploding-head size=5x rotate=180deg >}}
 {{< iconify exploding-head size=Huge >}}
@@ -40,10 +42,11 @@ Iconify API provides additional attributes: <https://docs.iconify.design/iconify
 Currently, this extension supports: `width`, `height`, `title`[^2], `label`[^2] (_i.e._, `aria-label`), `flip`, and `rotate`.
 
 ``` markdown
-{{< iconify <set> <icon-name> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> >}}
+{{< iconify <set> <icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> >}}
+{{< iconify <set:icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> >}}
 ```
 
-[^2]: `title` and `label` takes the following default value: `Icon <icon-name> from <set> Iconify.design set.`.
+[^2]: `title` and `label` takes the following default value: `Icon <icon> from <set> Iconify.design set.`.
 
 ### Sizing Icons
 

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -79,9 +79,16 @@ return {
     -- detect html (excluding epub which won't handle fa)
     if quarto.doc.is_format("html:js") then
       ensure_html_deps()
-      local set = "fluent-emoji"
       local icon = pandoc.utils.stringify(args[1])
-      if #args > 1 then
+      local set = "fluent-emoji"
+
+      if string.find(icon, ":") then
+        if #args > 1 then
+          print('Warning: use "set:icon" or "set icon" syntax, not both.')
+        end
+        set = string.sub(icon, 1, string.find(icon, ":") - 1)
+        icon = string.sub(icon, string.find(icon, ":") + 1)
+      elseif #args > 1 then
         set = icon
         icon = pandoc.utils.stringify(args[2])
       end

--- a/example.qmd
+++ b/example.qmd
@@ -6,14 +6,15 @@ format: html
 This extension allows you to use [Iconify](https://icon-sets.iconify.design/) icons in your Quarto HTML documents.
 It provides an `{{{< iconify >}}}` shortcode:
 
-- Mandatory `<icon-name>`:
+- Mandatory `<icon>`:
   ``` markdown
-  {{{< iconify <icon-name> >}}}
+  {{{< iconify <icon> >}}}
+  {{{< iconify <set:icon> >}}}
   ```
 
 - Optional `<set>` (default is `fluent-emoji`) `<size=...>`, `<width=...>`, `<height=...>`, `<flip=...>`, and `<rotate=...>`:
   ``` markdown
-  {{{< iconify <set> <icon-name> <size=...> <width=...> <height=...> <flip=...> <rotate=...> >}}}
+  {{{< iconify <set> <icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> >}}}
   ```
   If `<size=...>` is defined, `<width=...>` and `<height=...>` are not used.  
   See <https://docs.iconify.design/iconify-icon/> for more details.
@@ -23,6 +24,8 @@ For example:
 | Shortcode                                                                              | Icon                                                                   |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `{{{< iconify exploding-head >}}}`                                                     | {{< iconify exploding-head >}}                                         |
+| `{{{< iconify fluent-emoji exploding-head >}}}`                                        | {{< iconify exploding-head >}}                                         |
+| `{{{< iconify fluent-emoji:exploding-head >}}}`                                        | {{< iconify exploding-head >}}                                         |
 | `{{{< iconify exploding-head size=2xl >}}}`                                            | {{< iconify exploding-head size=2xl >}}                                |
 | `{{{< iconify exploding-head size=5x rotate=180deg >}}}`                               | {{< iconify exploding-head size=5x rotate=180deg >}}                   |
 | `{{{< iconify exploding-head size=Huge >}}}`                                           | {{< iconify exploding-head size=Huge >}}                               |


### PR DESCRIPTION
Currently, the shortcode expects the format "set icon", but the website provides the format "set:icon". This pull request modifies the shortcode to support both formats, by detecting the ":" and splitting it into "set" and "icon". This improvement will enhance the user experience when copying and using icons from the Iconify website.

Fixes #19