### PR TITLE
fix: use proper warning message for `set:icon` or `set icon`

### DIFF
--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -83,8 +83,10 @@ return {
       local set = "fluent-emoji"
 
       if #args > 1 and string.find(pandoc.utils.stringify(args[2]), ":") then
-        quarto.log.warning('Use "set:icon" or "set icon" syntax, not both!')
-        quarto.log.warning('Using "set:icon" syntax!')
+        quarto.log.warning(
+          'Use "set:icon" or "set icon" syntax, not both!' ..
+          'Using "set:icon" syntax and discarding first argument!'
+        )
         icon = pandoc.utils.stringify(args[2])
       end
 

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -82,10 +82,13 @@ return {
       local icon = pandoc.utils.stringify(args[1])
       local set = "fluent-emoji"
 
+      if #args > 1 and string.find(pandoc.utils.stringify(args[2]), ":") then
+        quarto.log.warning('Use "set:icon" or "set icon" syntax, not both!')
+        quarto.log.warning('Using "set:icon" syntax!')
+        icon = pandoc.utils.stringify(args[2])
+      end
+
       if string.find(icon, ":") then
-        if #args > 1 then
-          print('Warning: use "set:icon" or "set icon" syntax, not both.')
-        end
         set = string.sub(icon, 1, string.find(icon, ":") - 1)
         icon = string.sub(icon, string.find(icon, ":") + 1)
       elseif #args > 1 then

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -84,7 +84,7 @@ return {
 
       if #args > 1 and string.find(pandoc.utils.stringify(args[2]), ":") then
         quarto.log.warning(
-          'Use "set:icon" or "set icon" syntax, not both!' ..
+          'Use "set:icon" or "set icon" syntax, not both! ' ..
           'Using "set:icon" syntax and discarding first argument!'
         )
         icon = pandoc.utils.stringify(args[2])


### PR DESCRIPTION
This pull request fixes the warning message for the `set:icon` or `set icon` syntax in the `iconify.lua` file. Previously, the warning message was not properly displayed when both syntaxes were used. With this fix, the warning message is now displayed correctly and provides clear instructions on the correct syntax to use.