### PR TITLE
docs: Add Quarto Iconify Example for simple-icons:quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To embed an icon, use the `{{< iconify >}}` shortcode[^1]. For example:
 {{< iconify twemoji 1st-place-medal >}}
 {{< iconify line-md loading-alt-loop >}}
 {{< iconify fa6-brands apple width=50px height=10px rotate=90deg flip=vertical >}}
+{{< iconify simple-icons:quarto >}}
 ```
 
 This extension includes support for thousands of icons (including animated icons).

--- a/example.qmd
+++ b/example.qmd
@@ -33,3 +33,4 @@ For example:
 | `{{{< iconify twemoji 1st-place-medal >}}}`                                            | {{< iconify twemoji 1st-place-medal >}}                                |
 | `{{{< iconify line-md loading-alt-loop >}}}`                                           | {{< iconify line-md loading-alt-loop >}}                               |
 | `{{{< iconify fa6-brands apple width=50px height=10px rotate=90deg flip=vertical >}}}` | {{< iconify fa6-brands apple width=50px rotate=90deg flip=vertical >}} |
+| `{{{< iconify simple-icons:quarto >}}}`                                                | {{< iconify simple-icons:quarto >}}                                    |


### PR DESCRIPTION
Fixes #24

Adds the `{{< iconify simple-icons:quarto >}}` shortcode to both the example file and the README documentation to showcase the usage of the Quarto icon from the Simple Icons collection.

- **Example File (`example.qmd`):**
  - Inserts the `{{< iconify simple-icons:quarto >}}` shortcode into the table of examples, demonstrating its visual representation alongside other icons.

- **README File (`README.md`):**
  - Updates the example usage section to include the `{{< iconify simple-icons:quarto >}}` shortcode, providing users with a comprehensive list of icon examples available through the extension.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mcanouil/quarto-iconify/issues/24?shareId=7c951d11-e58e-42e4-a769-9ada80f422e5).