### PR TITLE
fix: Add `role` attribute to `<iconify-icon>` tag for accessibility

### DIFF
--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -141,7 +141,7 @@ return {
 
       return pandoc.RawInline(
         'html',
-        '<iconify-icon inline' .. attributes .. '></iconify-icon>'
+        '<iconify-icon inline=true role="img"' .. attributes .. '></iconify-icon>'
       )
     else
       return pandoc.Null()


### PR DESCRIPTION
This pull request fixes #28 by adding the `role="img"` attribute to the `<iconify-icon>` tag. This change ensures that the icon is accessible by screen readers and resolves the AxDevTools Accessibility issue related to the missing `role` attribute.