### PR TITLE
refactor: extension configuration structure under `extensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,20 @@ Currently, this extension supports: `<set>`[^1], `size`[^2], `width`[^2], `heigh
 Defining default values for attributes[^7]:
 
 ```yaml
-iconify:
-  set: "octicon"
-  size: "Huge"
-  width: "1em"
-  height: "1em"
-  flip: "horizontal"
-  rotate: "90deg"
-  inline: true
-  mode: "svg"
-  style: "color: #b22222;"
+extensions:
+  iconify:
+    set: "octicon"
+    size: "Huge"
+    width: "1em"
+    height: "1em"
+    flip: "horizontal"
+    rotate: "90deg"
+    inline: true
+    mode: "svg"
+    style: "color: #b22222;"
 ```
+
+**Note:** The top-level `iconify:` configuration is deprecated but still supported for backward compatibility. A warning will be displayed when using the deprecated format. Please migrate to the new nested structure shown above.
 
 [^1]: The default icon set is `octicon` (source: <https://github.com/microsoft/fluentui-emoji>).
 [^2]: If `<size=...>` is defined, `<width=...>` and `<height=...>` are not used.
@@ -66,7 +69,7 @@ iconify:
 [^4]: `inline` is a boolean attribute that can be set to `true` or `false`. Default is `true`.
 [^5]: `mode` is a string attribute that can be set to `"svg"`, `"style"`, `"bg"`, and `"mask"`. Default is `"svg"`. See [Iconify renderings mode](https://iconify.design/docs/iconify-icon/modes.html) for more details.
 [^6]: `style` is a string attribute expected to be a CSS style.
-[^7]: The default values can be defined in the YAML header of the document.
+[^7]: The default values can be defined in the YAML header of the document using the new nested structure under `extensions.iconify`. The old top-level `iconify` configuration is deprecated but still supported.
   `icon`, `title`, and `label` have to be defined in the shortcode.
 
 ### Sizing Icons

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -25,6 +25,10 @@
 --- @type function
 local stringify = pandoc.utils.stringify
 
+--- Flag to track if deprecation warning has been shown
+--- @type boolean
+local deprecation_warning_shown = false
+
 --- Ensure Iconify HTML dependencies are included.
 --- @return nil
 local function ensure_html_deps()
@@ -48,13 +52,16 @@ end
 --- @return string|nil The value from deprecated config, or nil if not found
 local function check_deprecated_config(meta, key)
   if not is_empty(meta['iconify']) and not is_empty(meta['iconify'][key]) then
-    quarto.log.warning(
-      'Top-level "iconify" configuration is deprecated. ' ..
-      'Please use:\n' ..
-      'extensions:\n' ..
-      '  iconify:\n' ..
-      '    ' .. key .. ': value'
-    )
+    if not deprecation_warning_shown then
+      quarto.log.warning(
+        'Top-level "iconify" configuration is deprecated. ' ..
+        'Please use:\n' ..
+        'extensions:\n' ..
+        '  iconify:\n' ..
+        '    ' .. key .. ': value'
+      )
+      deprecation_warning_shown = true
+    end
     return stringify(meta['iconify'][key])
   end
   return nil

--- a/example.qmd
+++ b/example.qmd
@@ -6,8 +6,9 @@ format:
     reference-location: margin
     code-overflow: wrap
     code-tools: true
-iconify:
-  style: "color: #b22222;"
+extensions:
+  iconify:
+    style: "color: #b22222;"
 ---
 
 This extension provides support to free and open source icons provided by [Iconify](https://icon-sets.iconify.design/).
@@ -40,15 +41,16 @@ It provides an `{{{< iconify >}}}` shortcode:
 - Defining default values for attributes[^7]:
 
   ```yaml
-  iconify:
-    set: "octicon"
-    width: "1em"
-    height: "1em"
-    flip: "horizontal"
-    rotate: "90deg"
-    inline: true
-    mode: "svg"
-    style: "color: #b22222;"
+  extensions:
+    iconify:
+      set: "octicon"
+      width: "1em"
+      height: "1em"
+      flip: "horizontal"
+      rotate: "90deg"
+      inline: true
+      mode: "svg"
+      style: "color: #b22222;"
   ```
 
 [^1]: The default icon set is `octicon` (source: <https://github.com/microsoft/fluentui-emoji>).
@@ -57,7 +59,7 @@ It provides an `{{{< iconify >}}}` shortcode:
 [^4]: `inline` is a boolean attribute that can be set to `true` or `false`. Default is `true`.
 [^5]: `mode` is a string attribute that can be set to `"svg"`, `"style"`, `"bg"`, and `"mask"`. Default is `"svg"`. See [Iconify renderings mode](https://iconify.design/docs/iconify-icon/modes.html) for more details.
 [^6]: `style` is a string attribute expected to be a CSS style.
-[^7]: The default values can be defined in the YAML header of the document.
+[^7]: The default values can be defined in the YAML header of the document using the new nested structure under `extensions.iconify`. The old top-level `iconify` configuration is deprecated but still supported.
   `icon`, `title`, and `label` have to be defined in the shortcode.
 
 For example:


### PR DESCRIPTION
Scope the extension configuration under `extensions.iconify` to improve organisation and clarity. The previous top-level `iconify` configuration is now deprecated but remains supported for backward compatibility. A warning prompts users to migrate to the new structure.

- https://github.com/quarto-dev/quarto-cli/issues/12894