### PR TITLE
fix: add missing style option to schema

### DIFF
--- a/_extensions/iconify/_schema.yml
+++ b/_extensions/iconify/_schema.yml
@@ -24,6 +24,9 @@ options:
   rotate:
     type: string
     description: "Default rotation for icons (e.g., '90deg', '180deg', '1')."
+  style:
+    type: string
+    description: "Default additional inline CSS styles applied to all icons."
   inline:
     type: boolean
     default: true


### PR DESCRIPTION
## Summary

- Add the `style` option (type: string) that was missing from the schema but is read by the Lua filter for applying inline CSS to icons.

## Test plan

- [ ] Verify `_schema.yml` parses correctly.
- [ ] Verify IDE shows the `style` option in completions.