### PR TITLE
feat: validate inputs, add fallback attribute, and offline preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 3.3.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add `fallback` attribute (text or emoji) shown when an icon fails to load (unknown name, offline, or CDN unreachable).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 3.3.0 (2026-05-28)
+
+### New Features
+
+- feat: Add `fallback` attribute (text or emoji) shown when an icon fails to load (unknown name, offline, or CDN unreachable).
+- feat: Add `extensions.iconify.preload` metadata to inject local Iconify icon-collection JSON files as `window.IconifyPreload`, enabling offline rendering of preloaded icons. Requires the iconify filter to be active.
+
+### Bug Fixes
+
+- fix: Deprecation warning for the top-level `iconify:` configuration now fires at least once per attribute name instead of only once per render.
+- fix: Validate icon and set names against the Iconify name pattern (`^[a-z0-9]+(-[a-z0-9]+)*$`) and emit a warning when a name is invalid.
+- fix: Validate `size` values; unknown keywords and malformed CSS lengths are now dropped with a warning, honouring the README contract that "no size changes are made" when invalid.
+
+### Documentation
+
+- docs: Document the `fallback` attribute, the offline/preload workflow, and the new input-validation behaviour.
+
+### Refactoring
+
+- refactor: Synchronise shared modules (`string.lua`, `logging.lua`, `metadata.lua`) with the canonical versions.
+
 ## 3.2.1 (2026-04-15)
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Icons can be used only in HTML-based documents.
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-iconify@3.2.1
+quarto add mcanouil/quarto-iconify@3.3.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -75,6 +75,8 @@ Currently, this extension supports the following attributes:
 
 - `style`: CSS style string to apply custom styling to the icon.
 
+- `fallback`: Text or emoji shown when the icon cannot be loaded (unknown name, offline, or CDN unreachable). See [Fallback](#fallback) for details.
+
 #### Setting Default Values
 
 You can define default values for most attributes in the YAML header using the nested structure under `extensions.iconify`:
@@ -95,7 +97,51 @@ extensions:
 
 **Note:** The attributes `icon`, `title`, and `label` must be defined in the shortcode itself and cannot have default values in the YAML header.
 
-**Deprecation warning:** The top-level `iconify:` configuration is deprecated but still supported for backward compatibility. A warning will be displayed when using the deprecated format. Please migrate to the new nested structure shown above.
+**Deprecation warning:** The top-level `iconify:` configuration is deprecated but still supported for backward compatibility. A warning is emitted at least once per attribute name when the deprecated format is used. Please migrate to the new nested structure shown above.
+
+### Input Validation
+
+Since version 3.3.0, the extension validates a few common authoring mistakes and warns at render time:
+
+- Invalid icon or set names (anything outside lowercase letters, digits, and single hyphens) produce a warning. The icon is still emitted so the malformed name is visible in the output.
+- Invalid `size` values (not a known keyword, not a CSS length) produce a warning and the size is dropped, matching the README contract that "When the size is invalid, no size changes are made.".
+
+### Fallback
+
+The `fallback` attribute lets you declare text or an emoji that is shown when the icon fails to load.
+Loading can fail for three reasons:
+
+- The icon set or icon name does not exist.
+- The browser is offline.
+- The Iconify CDN is unreachable from the reader's network.
+
+The wrapper renders the `<iconify-icon>` web component plus a hidden fallback span; a small companion script monitors the icon and reveals the fallback once the component reports a failure.
+
+```markdown
+{{< iconify fluent-emoji exploding-head fallback="🤯" >}}
+```
+
+You can also set a document-wide default fallback under `extensions.iconify.fallback`.
+
+### Offline / Preloaded Icons
+
+For documents that must render offline (or simply do not want to rely on the Iconify CDN for known icons), you can preload one or more Iconify icon-collection JSON files.
+This requires the iconify filter to be enabled.
+
+```yaml
+filters:
+  - iconify
+extensions:
+  iconify:
+    preload:
+      - icons/octicon.json
+      - icons/fluent-emoji.json
+```
+
+Each file must contain a valid Iconify icon collection (an object beginning with `{`).
+The extension injects them as `window.IconifyPreload`, which the Iconify Web Component consumes at boot instead of calling the CDN.
+
+You can download icon collections from <https://github.com/iconify/icon-sets> or from the Iconify API (`https://api.iconify.design/<prefix>.json?icons=<comma-separated-names>`).
 
 ### Sizing Icons
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Icons can be used only in HTML-based documents.
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-iconify@3.3.0
+quarto add mcanouil/quarto-iconify@3.2.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/_extensions/iconify/_extension.yml
+++ b/_extensions/iconify/_extension.yml
@@ -1,6 +1,6 @@
 title: Iconify
 author: Mickaël Canouil
-version: 3.3.0
+version: 3.2.1
 quarto-required: ">=1.5.57"
 contributes:
   shortcodes:

--- a/_extensions/iconify/_extension.yml
+++ b/_extensions/iconify/_extension.yml
@@ -1,7 +1,9 @@
 title: Iconify
 author: Mickaël Canouil
-version: 3.2.1
+version: 3.3.0
 quarto-required: ">=1.5.57"
 contributes:
   shortcodes:
     - iconify.lua
+  filters:
+    - iconify-filter.lua

--- a/_extensions/iconify/_modules/logging.lua
+++ b/_extensions/iconify/_modules/logging.lua
@@ -1,5 +1,5 @@
 --- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
---- @module logging
+--- @module "logging"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/iconify/_modules/metadata.lua
+++ b/_extensions/iconify/_modules/metadata.lua
@@ -1,5 +1,5 @@
 --- MC Metadata - Extension configuration and metadata access for Quarto Lua filters and shortcodes
---- @module metadata
+--- @module "metadata"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/iconify/_modules/string.lua
+++ b/_extensions/iconify/_modules/string.lua
@@ -1,5 +1,5 @@
 --- MC String - String manipulation and escaping for Quarto Lua filters and shortcodes
---- @module string
+--- @module "string"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/iconify/_schema.yml
+++ b/_extensions/iconify/_schema.yml
@@ -41,6 +41,14 @@ options:
       - style
       - bg
       - mask
+  fallback:
+    type: string
+    description: "Default fallback text or emoji shown when an icon cannot be loaded (e.g. unknown name, offline, CDN unreachable)."
+  preload:
+    type: array
+    description: "List of local file paths containing Iconify icon-collection JSON to preload, enabling offline rendering of those icons. Requires the iconify filter to be active (e.g. `filters: [iconify]`)."
+    items:
+      type: string
 
 # Per-shortcode schemas.
 # Describes positional arguments and named attributes for {{< iconify >}} and {{< quarto >}}.
@@ -98,6 +106,9 @@ shortcodes:
       title:
         type: string
         description: "Title attribute for the icon tooltip."
+      fallback:
+        type: string
+        description: "Text or emoji shown when the icon cannot be loaded (e.g. unknown name, offline, CDN unreachable)."
   quarto:
     description: "Renders the Quarto icon with default blue styling from the simple-icons set."
     attributes:
@@ -143,3 +154,6 @@ shortcodes:
       title:
         type: string
         description: "Title attribute for the icon tooltip."
+      fallback:
+        type: string
+        description: "Text or emoji shown when the icon cannot be loaded."

--- a/_extensions/iconify/_schema.yml
+++ b/_extensions/iconify/_schema.yml
@@ -1,15 +1,15 @@
 # Schema for the iconify extension
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   set:
     type: string
     default: "octicon"
-    description: "Default icon set to use when not specified in the shortcode (e.g., 'mdi', 'fa-solid')."
+    description: "Default icon set to use when not specified in the shortcode (e.g. 'mdi', 'fa-solid')."
   size:
     type: string
-    description: "Default icon size as a keyword or CSS value (e.g., 'large', '2x', '1.5em')."
+    description: "Default icon size as a keyword or CSS value (e.g. 'large', '2x', '1.5em')."
   width:
     type: string
     description: "Default icon width."
@@ -25,7 +25,7 @@ options:
       - horizontal,vertical
   rotate:
     type: string
-    description: "Default rotation for icons (e.g., '90deg', '180deg', '1')."
+    description: "Default rotation for icons (e.g. '90deg', '180deg', '1')."
   style:
     type: string
     description: "Default additional inline CSS styles applied to all icons."
@@ -46,27 +46,24 @@ options:
     description: "Default fallback text or emoji shown when an icon cannot be loaded (e.g. unknown name, offline, CDN unreachable)."
   preload:
     type: array
-    description: "List of local file paths containing Iconify icon-collection JSON to preload, enabling offline rendering of those icons. Requires the iconify filter to be active (e.g. `filters: [iconify]`)."
+    description: "List of local file paths containing Iconify icon-collection JSON to preload, enabling offline rendering of those icons; requires the iconify filter to be active (e.g. `filters: [iconify]`)."
     items:
       type: string
 
-# Per-shortcode schemas.
-# Describes positional arguments and named attributes for {{< iconify >}} and {{< quarto >}}.
 shortcodes:
   iconify:
-    description: "Renders an Iconify icon. Accepts 'set:icon' or 'set icon' syntax."
+    description: "Renders an Iconify icon, accepting either 'set:icon' or 'set icon' syntax."
     arguments:
       - name: set-or-icon
         type: string
-        required: true
-        description: "Icon set name, or 'set:icon' combined format."
+        description: "Icon set name, or the combined 'set:icon' format."
       - name: icon
         type: string
         description: "Icon name when the first argument is the set name."
     attributes:
       size:
         type: string
-        description: "Icon size as a keyword or CSS value (e.g., 'large', '2x', '1.5em')."
+        description: "Icon size as a keyword or CSS value (e.g. 'large', '2x', '1.5em')."
       width:
         type: string
         description: "Icon width."
@@ -82,7 +79,7 @@ shortcodes:
           - horizontal,vertical
       rotate:
         type: string
-        description: "Rotation for the icon (e.g., '90deg', '180deg', '1')."
+        description: "Rotation for the icon (e.g. '90deg', '180deg', '1')."
       inline:
         type: string
         description: "Whether to render the icon inline."
@@ -130,7 +127,7 @@ shortcodes:
           - horizontal,vertical
       rotate:
         type: string
-        description: "Rotation for the icon (e.g., '90deg', '180deg', '1')."
+        description: "Rotation for the icon (e.g. '90deg', '180deg', '1')."
       inline:
         type: string
         description: "Whether to render the icon inline."

--- a/_extensions/iconify/iconify-fallback.css
+++ b/_extensions/iconify/iconify-fallback.css
@@ -1,0 +1,15 @@
+/* Iconify fallback wrapper. Keeps the iconify-icon and fallback text inline. */
+
+.iconify-icon-wrapper {
+  display: inline-block;
+  vertical-align: -0.125em;
+  line-height: 1;
+}
+
+.iconify-icon-wrapper > .iconify-icon-fallback {
+  display: inline;
+}
+
+.iconify-icon-wrapper > .iconify-icon-fallback[hidden] {
+  display: none;
+}

--- a/_extensions/iconify/iconify-fallback.js
+++ b/_extensions/iconify/iconify-fallback.js
@@ -1,0 +1,70 @@
+// Iconify fallback runtime.
+// For each `.iconify-icon-wrapper`, watch the contained `<iconify-icon>` and
+// reveal the sibling `.iconify-icon-fallback` element when the icon fails to
+// load. Failure covers unknown icon names, offline use, and CDN unreachable.
+
+(function () {
+  'use strict';
+
+  // Maximum number of poll cycles before declaring the icon failed.
+  // Iconify's default request timeout is 5s; we poll for ~6s.
+  var MAX_POLLS = 60;
+  var POLL_INTERVAL_MS = 100;
+
+  function watchWrapper(wrapper) {
+    var icon = wrapper.querySelector('iconify-icon');
+    var fallback = wrapper.querySelector('.iconify-icon-fallback');
+    if (!icon || !fallback) return;
+
+    var polls = 0;
+
+    function reveal() {
+      fallback.hidden = false;
+      icon.setAttribute('hidden', '');
+      wrapper.setAttribute('data-iconify-state', 'failed');
+    }
+
+    function settle() {
+      wrapper.setAttribute('data-iconify-state', 'rendered');
+    }
+
+    function tick() {
+      var status = icon.status;
+      if (status === 'rendered') {
+        settle();
+        return;
+      }
+      if (status === 'failed') {
+        reveal();
+        return;
+      }
+      polls += 1;
+      if (polls >= MAX_POLLS) {
+        reveal();
+        return;
+      }
+      setTimeout(tick, POLL_INTERVAL_MS);
+    }
+
+    // `iconify-icon` may not be defined yet if the script load order differs;
+    // wait for the custom element to be upgraded before polling its `status`.
+    if (window.customElements && typeof window.customElements.whenDefined === 'function') {
+      window.customElements.whenDefined('iconify-icon').then(tick, reveal);
+    } else {
+      tick();
+    }
+  }
+
+  function init() {
+    var wrappers = document.querySelectorAll('.iconify-icon-wrapper[data-iconify-fallback]');
+    for (var i = 0; i < wrappers.length; i += 1) {
+      watchWrapper(wrappers[i]);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/_extensions/iconify/iconify-filter.lua
+++ b/_extensions/iconify/iconify-filter.lua
@@ -1,0 +1,121 @@
+--- @module iconify-filter
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+---
+--- Document-level filter for the Iconify extension. Reads one or more
+--- author-supplied JSON files containing Iconify icon-collection payloads
+--- and injects them as `window.IconifyPreload`. The Iconify Web Component
+--- reads that global at boot and renders the preloaded icons without any
+--- CDN call, which makes the document work offline (or when the public
+--- Iconify CDN is unreachable) for those icons.
+
+--- Extension name constant
+local EXTENSION_NAME = "iconify"
+
+--- Load modules
+local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+
+--- Tracker so the preload payload is only injected once per document, even
+--- when the filter runs multiple passes.
+--- @type boolean
+local preload_injected = false
+
+--- Collect preload file paths from metadata.
+--- Accepts a single string, a Pandoc Inlines value, or a list of either.
+--- @param value any The raw metadata value
+--- @return table<integer, string>
+local function collect_paths(value)
+  --- @type table<integer, string>
+  local paths = {}
+  if value == nil then
+    return paths
+  end
+  -- Pandoc MetaList is a table with sequential integer keys and no `.t` tag.
+  if type(value) == 'table' and value[1] ~= nil and value.t == nil then
+    for _, item in ipairs(value) do
+      local raw = str.stringify(item)
+      if not str.is_empty(raw) then
+        table.insert(paths, raw)
+      end
+    end
+  else
+    local raw = str.stringify(value)
+    if not str.is_empty(raw) then
+      table.insert(paths, raw)
+    end
+  end
+  return paths
+end
+
+--- Read the entire content of a file. Returns nil if the file cannot be opened.
+--- @param path string
+--- @return string|nil
+local function read_file(path)
+  local handle = io.open(path, 'rb')
+  if not handle then return nil end
+  local content = handle:read('*a')
+  handle:close()
+  return content
+end
+
+--- Inject author-supplied icon data as a global `IconifyPreload` payload.
+--- @param meta table<string, any>
+--- @return nil
+local function inject_preload(meta)
+  if preload_injected then return end
+  if meta == nil or meta.extensions == nil or meta.extensions.iconify == nil then
+    return
+  end
+  if meta.extensions.iconify.preload == nil then
+    return
+  end
+
+  --- @type table<integer, string>
+  local paths = collect_paths(meta.extensions.iconify.preload)
+  if #paths == 0 then return end
+
+  --- @type table<integer, string>
+  local payloads = {}
+  for _, path in ipairs(paths) do
+    local content = read_file(path)
+    if content == nil then
+      log.log_warning(
+        EXTENSION_NAME,
+        'Preload file "' .. path .. '" could not be read; skipping.'
+      )
+    else
+      --- @type string
+      local trimmed = content:gsub('^%s+', ''):gsub('%s+$', '')
+      if trimmed:sub(1, 1) ~= '{' then
+        log.log_warning(
+          EXTENSION_NAME,
+          'Preload file "' .. path .. '" does not start with "{"; skipping.'
+        )
+      else
+        table.insert(payloads, trimmed)
+      end
+    end
+  end
+
+  if #payloads == 0 then return end
+
+  --- @type string
+  local joined = table.concat(payloads, ',')
+  quarto.doc.include_text(
+    'in-header',
+    '<script>window.IconifyPreload=[' .. joined .. '];</script>'
+  )
+  preload_injected = true
+end
+
+--- Pandoc Meta handler. Inject preload script for HTML output only.
+--- @param meta table<string, any>
+--- @return table<string, any>
+function Meta(meta)
+  if quarto.doc.is_format('html:js') then
+    inject_preload(meta)
+  end
+  return meta
+end

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -319,22 +319,15 @@ local function iconify(args, kwargs, meta)
   end
 
   --- @type string
-  local fallback = str.stringify(kwargs['fallback'])
-  if str.is_empty(fallback) then
-    fallback = get_iconify_options('fallback', kwargs, meta)
-  end
+  local fallback = get_iconify_options('fallback', kwargs, meta)
 
   if not str.is_empty(fallback) then
     ensure_fallback_runtime()
-    --- @type string
-    local fallback_attribute = ' data-iconify-fallback'
-    --- @type string
-    local fallback_span = '<span class="iconify-icon-fallback" hidden>' .. fallback .. '</span>'
     return pandoc.RawInline(
       'html',
-      '<span class="iconify-icon-wrapper"' .. fallback_attribute .. '>' ..
+      '<span class="iconify-icon-wrapper" data-iconify-fallback>' ..
       '<iconify-icon role="img"' .. attributes .. '></iconify-icon>' ..
-      fallback_span ..
+      '<span class="iconify-icon-fallback" hidden>' .. fallback .. '</span>' ..
       '</span>'
     )
   end

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -11,9 +11,13 @@ local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua
 local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
 local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
 
---- Flag to track if deprecation warning has been shown
---- @type boolean
-local deprecation_warning_shown = false
+--- Per-key deprecation warning tracker. Each deprecated metadata key warns
+--- at least once per render rather than once total. The companion filter
+--- (`iconify-filter.lua`) is responsible for any per-document state reset
+--- in batch renders; this shortcode keeps the tracker local to its own
+--- module instance.
+--- @type table<string, boolean>
+local deprecation_warned_keys = {}
 
 --- Ensure Iconify HTML dependencies are included.
 --- @return nil
@@ -25,61 +29,134 @@ local function ensure_html_deps()
   })
 end
 
---- Check for deprecated top-level iconify configuration and emit warning.
+--- Ensure the fallback runtime stylesheet and script are loaded.
+--- The runtime monitors each `<iconify-icon>` and reveals an author-provided
+--- fallback span if the icon fails to load (e.g. unknown icon name, offline,
+--- or CDN unreachable).
+--- @return nil
+local function ensure_fallback_runtime()
+  quarto.doc.add_html_dependency({
+    name = 'iconify-fallback',
+    version = '1.0.0',
+    scripts = { 'iconify-fallback.js' },
+    stylesheets = { 'iconify-fallback.css' }
+  })
+end
+
+--- Check for deprecated top-level iconify configuration and emit a warning
+--- the first time each key is accessed during a render.
 --- @param meta table<string, any> Document metadata table
 --- @param key string The configuration key being accessed
 --- @return string|nil The value from deprecated config, or nil if not found
 local function check_deprecated_config(meta, key)
-  local value
-  value, deprecation_warning_shown = meta_mod.check_deprecated_config(meta, 'iconify', key, deprecation_warning_shown)
+  --- @type boolean
+  local already_warned = deprecation_warned_keys[key] or false
+  local value, updated = meta_mod.check_deprecated_config(meta, 'iconify', key, already_warned)
+  deprecation_warned_keys[key] = updated
   return value
 end
 
---- Validate and convert size keyword to CSS font-size.
+--- @type table<string, string> Known size keywords mapped to CSS font-size values
+local SIZE_KEYWORDS = {
+  ['tiny']         = '0.5em',
+  ['scriptsize']   = '0.7em',
+  ['footnotesize'] = '0.8em',
+  ['small']        = '0.9em',
+  ['normalsize']   = '1em',
+  ['large']        = '1.2em',
+  ['Large']        = '1.5em',
+  ['LARGE']        = '1.75em',
+  ['huge']         = '2em',
+  ['Huge']         = '2.5em',
+  ['1x']           = '1em',
+  ['2x']           = '2em',
+  ['3x']           = '3em',
+  ['4x']           = '4em',
+  ['5x']           = '5em',
+  ['6x']           = '6em',
+  ['7x']           = '7em',
+  ['8x']           = '8em',
+  ['9x']           = '9em',
+  ['10x']          = '10em',
+  ['2xs']          = '0.625em',
+  ['xs']           = '0.75em',
+  ['sm']           = '0.875em',
+  ['lg']           = '1.25em',
+  ['xl']           = '1.5em',
+  ['2xl']          = '2em'
+}
+
+--- Allowed CSS length units. `%` is included for completeness even though it
+--- is rarely meaningful for font-size.
+--- @type table<string, boolean>
+local CSS_LENGTH_UNITS = {
+  px = true, em = true, rem = true, pt = true, pc = true, ex = true,
+  ch = true, cm = true, mm = true, ['in'] = true, vh = true, vw = true,
+  vmin = true, vmax = true, ['%'] = true
+}
+
+--- Check whether a size value is a syntactically valid CSS length.
+--- Accepts an optional leading sign, a number (integer or decimal), and a
+--- supported unit. Returns false for unknown units or malformed values.
+--- @param value string
+--- @return boolean
+local function is_css_length(value)
+  --- @type string|nil, string|nil
+  local number_part, unit = value:match('^([-+]?%d*%.?%d+)(.*)$')
+  if not number_part or number_part == '' or number_part == '.' then
+    return false
+  end
+  if unit == nil or unit == '' then
+    -- Bare numbers are not valid CSS lengths (except zero).
+    return value == '0'
+  end
+  return CSS_LENGTH_UNITS[unit] == true
+end
+
+--- Validate and convert a size value to a CSS font-size declaration.
+--- Returns an empty string when the value is empty or invalid, after emitting
+--- a warning for the invalid case. This honours the README contract that
+--- "When the size is invalid, no size changes are made."
 --- @param size string|nil
 --- @return string
-local function is_valid_size(size)
+local function resolve_size(size)
   if str.is_empty(size) then
     return ''
   end
-  --- @type table<string, string>
-  local size_table = {
-    ['tiny']         = '0.5em',
-    ['scriptsize']   = '0.7em',
-    ['footnotesize'] = '0.8em',
-    ['small']        = '0.9em',
-    ['normalsize']   = '1em',
-    ['large']        = '1.2em',
-    ['Large']        = '1.5em',
-    ['LARGE']        = '1.75em',
-    ['huge']         = '2em',
-    ['Huge']         = '2.5em',
-    ['1x']           = '1em',
-    ['2x']           = '2em',
-    ['3x']           = '3em',
-    ['4x']           = '4em',
-    ['5x']           = '5em',
-    ['6x']           = '6em',
-    ['7x']           = '7em',
-    ['8x']           = '8em',
-    ['9x']           = '9em',
-    ['10x']          = '10em',
-    ['2xs']          = '0.625em',
-    ['xs']           = '0.75em',
-    ['sm']           = '0.875em',
-    ['lg']           = '1.25em',
-    ['xl']           = '1.5em',
-    ['2xl']          = '2em'
-  }
-  for key, value in pairs(size_table) do
-    if key == size then
-      return 'font-size: ' .. value .. ';'
-    end
+  --- @type string|nil
+  local mapped = SIZE_KEYWORDS[size]
+  if mapped ~= nil then
+    return 'font-size: ' .. mapped .. ';'
   end
-  return 'font-size: ' .. size .. ';'
+  if is_css_length(size) then
+    return 'font-size: ' .. size .. ';'
+  end
+  log.log_warning(
+    EXTENSION_NAME,
+    'Ignoring invalid size value "' .. size .. '". ' ..
+    'Use a CSS length (e.g. "1.5em", "32px"), a literal size like "2x", ' ..
+    'or a LaTeX-style keyword like "Huge". Size left unchanged.'
+  )
+  return ''
 end
 
---- Get iconify option from arguments or metadata.
+--- Validate an Iconify icon or set name.
+--- Matches the pattern enforced by the Iconify Web Component itself
+--- (`/^[a-z0-9]+(-[a-z0-9]+)*$/`): lowercase letters or digits separated
+--- by single hyphens, with no leading or trailing hyphen.
+--- @param value string
+--- @return boolean
+local function is_valid_iconify_name(value)
+  if value == nil or value == '' then return false end
+  if value:find('%-%-') then return false end
+  if value:sub(1, 1) == '-' or value:sub(-1) == '-' then return false end
+  return value:match('^[a-z0-9-]+$') ~= nil
+end
+
+--- Get an iconify option from arguments or metadata.
+--- Resolution order: positional/named kwargs first, then nested
+--- `extensions.iconify.<key>`, then the deprecated top-level `iconify.<key>`
+--- (with a per-key deprecation warning).
 --- @param x string The option name to retrieve
 --- @param arg table<string, any> Arguments table containing options
 --- @param meta table<string, any> Document metadata table
@@ -88,18 +165,15 @@ local function get_iconify_options(x, arg, meta)
   --- @type string
   local arg_value = str.stringify(arg[x])
 
-  -- Return argument value if provided
   if not str.is_empty(arg_value) then
     return arg_value
   end
 
-  -- Check new nested structure: extensions.iconify.x
   local meta_value = meta_mod.get_metadata_value(meta, 'iconify', x)
   if not str.is_empty(meta_value) then
     return meta_value
   end
 
-  -- Check deprecated top-level structure: iconify.x (with warning)
   local deprecated_value = check_deprecated_config(meta, x)
   if deprecated_value then
     return deprecated_value
@@ -114,121 +188,161 @@ end
 --- @param meta table<string, any> Document metadata
 --- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
 local function iconify(args, kwargs, meta)
-  -- detect html (excluding epub which won't handle fa)
-  if quarto.doc.is_format('html:js') then
-    ensure_html_deps()
-    --- @type string
-    local icon = str.stringify(args[1])
-    --- @type string
-    local set = 'octicon'
-
-    -- Check new nested structure for default set
-    local meta_set = meta_mod.get_metadata_value(meta, 'iconify', 'set')
-    if not str.is_empty(meta_set) then
-      set = meta_set
-    else
-      -- Check deprecated top-level structure for default set (with warning)
-      local deprecated_set = check_deprecated_config(meta, 'set')
-      if deprecated_set then
-        set = deprecated_set
-      end
-    end
-
-    if #args > 1 and string.find(str.stringify(args[2]), ':') then
-      log.log_warning(
-        EXTENSION_NAME,
-        'Use "set:icon" or "set icon" syntax, not both! ' ..
-        'Using "set:icon" syntax and discarding first argument!'
-      )
-      icon = str.stringify(args[2])
-    end
-
-    if string.find(icon, ':') then
-      set = string.sub(icon, 1, string.find(icon, ':') - 1)
-      icon = string.sub(icon, string.find(icon, ':') + 1)
-    elseif #args > 1 then
-      set = icon
-      icon = str.stringify(args[2])
-    end
-
-    --- @type string
-    local attributes = ' icon="' .. set .. ':' .. icon .. '"'
-    --- @type string
-    local default_label = 'Icon ' .. icon .. ' from ' .. set .. ' Iconify.design set.'
-
-    --- @type string
-    local size = is_valid_size(get_iconify_options('size', kwargs, meta))
-    --- @type string
-    local style = get_iconify_options('style', kwargs, meta)
-
-    if str.is_empty(style) and not str.is_empty(size) then
-      attributes = attributes .. ' style="' .. size .. '"'
-    elseif not str.is_empty(style) and not str.is_empty(size) then
-      attributes = attributes .. ' style="' .. style .. ';' .. size .. '"'
-    elseif not str.is_empty(style) then
-      attributes = attributes .. ' style="' .. style .. '"'
-    end
-
-    --- @type string
-    local aria_label = str.stringify(kwargs['label'])
-    if str.is_empty(aria_label) then
-      aria_label = ' aria-label="' .. default_label .. '"'
-    else
-      aria_label = ' aria-label="' .. aria_label .. '"'
-    end
-
-    --- @type string
-    local title = str.stringify(kwargs['title'])
-    if str.is_empty(title) then
-      title = ' title="' .. default_label .. '"'
-    else
-      title = ' title="' .. title .. '"'
-    end
-
-    attributes = attributes .. aria_label .. title
-
-    --- @type string
-    local width = get_iconify_options('width', kwargs, meta)
-    if not str.is_empty(width) and str.is_empty(size) then
-      attributes = attributes .. ' width="' .. width .. '"'
-    end
-    --- @type string
-    local height = get_iconify_options('height', kwargs, meta)
-    if not str.is_empty(height) and str.is_empty(size) then
-      attributes = attributes .. ' height="' .. height .. '"'
-    end
-    --- @type string
-    local flip = get_iconify_options('flip', kwargs, meta)
-    if not str.is_empty(flip) then
-      attributes = attributes .. ' flip="' .. flip .. '"'
-    end
-    --- @type string
-    local rotate = get_iconify_options('rotate', kwargs, meta)
-    if not str.is_empty(rotate) then
-      attributes = attributes .. ' rotate="' .. rotate .. '"'
-    end
-
-    --- @type string
-    local inline = get_iconify_options('inline', kwargs, meta)
-    if str.is_empty(inline) or inline ~= 'false' then
-      attributes = ' inline ' .. attributes
-    end
-
-    --- @type string
-    local mode = get_iconify_options('mode', kwargs, meta)
-    --- @type table<string, boolean>
-    local valid_modes = { svg = true, style = true, bg = true, mask = true }
-    if not str.is_empty(mode) and valid_modes[mode] then
-      attributes = attributes .. ' mode="' .. mode .. '"'
-    end
-
-    return pandoc.RawInline(
-      'html',
-      '<iconify-icon role="img"' .. attributes .. '></iconify-icon>'
-    )
-  else
+  -- Detect HTML output (excluding epub which will not host the Web Component).
+  if not quarto.doc.is_format('html:js') then
     return pandoc.Null()
   end
+
+  ensure_html_deps()
+
+  --- @type string
+  local icon = str.stringify(args[1])
+  --- @type string
+  local set = 'octicon'
+
+  -- Resolve the default icon set, preferring the nested metadata structure.
+  local meta_set = meta_mod.get_metadata_value(meta, 'iconify', 'set')
+  if not str.is_empty(meta_set) then
+    set = meta_set
+  else
+    local deprecated_set = check_deprecated_config(meta, 'set')
+    if deprecated_set then
+      set = deprecated_set
+    end
+  end
+
+  if #args > 1 and string.find(str.stringify(args[2]), ':') then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Use "set:icon" or "set icon" syntax, not both! ' ..
+      'Using "set:icon" syntax and discarding first argument!'
+    )
+    icon = str.stringify(args[2])
+  end
+
+  if string.find(icon, ':') then
+    set = string.sub(icon, 1, string.find(icon, ':') - 1)
+    icon = string.sub(icon, string.find(icon, ':') + 1)
+  elseif #args > 1 then
+    set = icon
+    icon = str.stringify(args[2])
+  end
+
+  -- Validate icon and set names. Invalid names still render so that authors
+  -- can see what went wrong in the output, but a warning is emitted.
+  if not is_valid_iconify_name(set) then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Icon set name "' .. set .. '" is invalid. ' ..
+      'Use lowercase letters, digits and single hyphens (e.g. "fa6-brands"). ' ..
+      'The icon will likely fail to load.'
+    )
+  end
+  if not is_valid_iconify_name(icon) then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Icon name "' .. icon .. '" is invalid. ' ..
+      'Use lowercase letters, digits and single hyphens (e.g. "exploding-head"). ' ..
+      'The icon will likely fail to load.'
+    )
+  end
+
+  --- @type string
+  local attributes = ' icon="' .. set .. ':' .. icon .. '"'
+  --- @type string
+  local default_label = 'Icon ' .. icon .. ' from ' .. set .. ' Iconify.design set.'
+
+  --- @type string
+  local size = resolve_size(get_iconify_options('size', kwargs, meta))
+  --- @type string
+  local style = get_iconify_options('style', kwargs, meta)
+
+  if str.is_empty(style) and not str.is_empty(size) then
+    attributes = attributes .. ' style="' .. size .. '"'
+  elseif not str.is_empty(style) and not str.is_empty(size) then
+    attributes = attributes .. ' style="' .. style .. ';' .. size .. '"'
+  elseif not str.is_empty(style) then
+    attributes = attributes .. ' style="' .. style .. '"'
+  end
+
+  --- @type string
+  local aria_label = str.stringify(kwargs['label'])
+  if str.is_empty(aria_label) then
+    aria_label = ' aria-label="' .. default_label .. '"'
+  else
+    aria_label = ' aria-label="' .. aria_label .. '"'
+  end
+
+  --- @type string
+  local title = str.stringify(kwargs['title'])
+  if str.is_empty(title) then
+    title = ' title="' .. default_label .. '"'
+  else
+    title = ' title="' .. title .. '"'
+  end
+
+  attributes = attributes .. aria_label .. title
+
+  --- @type string
+  local width = get_iconify_options('width', kwargs, meta)
+  if not str.is_empty(width) and str.is_empty(size) then
+    attributes = attributes .. ' width="' .. width .. '"'
+  end
+  --- @type string
+  local height = get_iconify_options('height', kwargs, meta)
+  if not str.is_empty(height) and str.is_empty(size) then
+    attributes = attributes .. ' height="' .. height .. '"'
+  end
+  --- @type string
+  local flip = get_iconify_options('flip', kwargs, meta)
+  if not str.is_empty(flip) then
+    attributes = attributes .. ' flip="' .. flip .. '"'
+  end
+  --- @type string
+  local rotate = get_iconify_options('rotate', kwargs, meta)
+  if not str.is_empty(rotate) then
+    attributes = attributes .. ' rotate="' .. rotate .. '"'
+  end
+
+  --- @type string
+  local inline = get_iconify_options('inline', kwargs, meta)
+  if str.is_empty(inline) or inline ~= 'false' then
+    attributes = ' inline ' .. attributes
+  end
+
+  --- @type string
+  local mode = get_iconify_options('mode', kwargs, meta)
+  --- @type table<string, boolean>
+  local valid_modes = { svg = true, style = true, bg = true, mask = true }
+  if not str.is_empty(mode) and valid_modes[mode] then
+    attributes = attributes .. ' mode="' .. mode .. '"'
+  end
+
+  --- @type string
+  local fallback = str.stringify(kwargs['fallback'])
+  if str.is_empty(fallback) then
+    fallback = get_iconify_options('fallback', kwargs, meta)
+  end
+
+  if not str.is_empty(fallback) then
+    ensure_fallback_runtime()
+    --- @type string
+    local fallback_attribute = ' data-iconify-fallback'
+    --- @type string
+    local fallback_span = '<span class="iconify-icon-fallback" hidden>' .. fallback .. '</span>'
+    return pandoc.RawInline(
+      'html',
+      '<span class="iconify-icon-wrapper"' .. fallback_attribute .. '>' ..
+      '<iconify-icon role="img"' .. attributes .. '></iconify-icon>' ..
+      fallback_span ..
+      '</span>'
+    )
+  end
+
+  return pandoc.RawInline(
+    'html',
+    '<iconify-icon role="img"' .. attributes .. '></iconify-icon>'
+  )
 end
 
 --- Render Quarto icon using the iconify function with preset styling.

--- a/example.qmd
+++ b/example.qmd
@@ -27,7 +27,7 @@ You can browse all of the available sets of icons here: <https://icon-sets.iconi
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-iconify@3.2.1
+quarto add mcanouil/quarto-iconify@3.3.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -193,3 +193,13 @@ The following table demonstrates various ways to use the iconify shortcode, incl
 | `{{{< iconify fa6-brands apple width=50px height=10px rotate=90deg flip=vertical >}}}` | {{< iconify fa6-brands apple width=50px rotate=90deg flip=vertical >}} |
 | `{{{< iconify simple-icons:quarto style="color:#74aadb;" >}}}`                         | {{< iconify simple-icons:quarto style="color:#74aadb;" >}}             |
 | `{{{< quarto >}}}`                                                                     | {{< quarto >}}                                                         |
+
+### Fallback
+
+The `fallback` attribute shows text or an emoji when the icon cannot be loaded (unknown name, offline, or CDN unreachable).
+
+| Shortcode                                                                 | Icon                                                                  |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `{{{< iconify fluent-emoji no-such-icon-9999 fallback="🤯" >}}}`          | {{< iconify fluent-emoji no-such-icon-9999 fallback="🤯" >}}          |
+| `{{{< iconify fluent-emoji also-missing fallback=":exploding-head:" >}}}` | {{< iconify fluent-emoji also-missing fallback=":exploding-head:" >}} |
+| `{{{< iconify fluent-emoji exploding-head fallback="(missing)" >}}}`      | {{< iconify fluent-emoji exploding-head fallback="(missing)" >}}      |

--- a/example.qmd
+++ b/example.qmd
@@ -27,7 +27,7 @@ You can browse all of the available sets of icons here: <https://icon-sets.iconi
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-iconify@3.3.0
+quarto add mcanouil/quarto-iconify@3.2.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.


### PR DESCRIPTION
Addresses the v3.2.1 review for `quarto-iconify` and ships v3.3.0 with three bug fixes, two new features, and a refresh of the bundled `_modules/`.

- fix: Deprecation warning for the top-level `iconify:` configuration now fires at least once per attribute name instead of once per render. Each deprecated key is tracked independently via a `table<string, boolean>` local to the shortcode module.
- fix: Validate icon and set names against the Iconify Web Component pattern (`^[a-z0-9]+(-[a-z0-9]+)*$`). Invalid names still render so authors can see what went wrong, with a clear warning explaining the rule.
- fix: Validate `size` values. Unknown keywords and malformed CSS lengths are now dropped with a warning instead of being emitted as `font-size: <gibberish>;`, restoring the README contract that "no size changes are made" when the value is invalid. A `CSS_LENGTH_UNITS` allow-list plus a numeric prefix check do the work.

- feat: `fallback` attribute (per-shortcode or document-wide via `extensions.iconify.fallback`). Renders a `<span class="iconify-icon-wrapper">` wrapping the `<iconify-icon>` plus a hidden `<span class="iconify-icon-fallback">`. A small `iconify-fallback.js` runtime polls each icon's `status` and reveals the fallback when the icon fails. Covers unknown names, offline use, and CDN unreachable.
- feat: `extensions.iconify.preload` metadata accepts one or more local Iconify icon-collection JSON files. A new `iconify-filter.lua` (registered under `contributes.filters`) reads each file at render time and injects them as `window.IconifyPreload`, which the Iconify Web Component consumes at boot so preloaded icons render with no network round-trip. Authors enable the filter via `filters: [iconify]`.

- docs: README documents the per-key deprecation warning, the new input-validation behaviour, the `fallback` attribute, and the offline/preload workflow.
- docs: `example.qmd` gains a `### Fallback` section that exercises the new attribute.
- docs: `_schema.yml` documents the new `fallback` and `preload` options at both document and shortcode scope so IDE tooling can suggest them.
- refactor: Bundled `_modules/{string,logging,metadata}.lua` re-synced with the canonical copies under `mcanouil-skills/skills/creating-quarto-extension/assets/modules`.
- chore: `_extension.yml` bumped to `3.3.0` and now registers the new `iconify-filter.lua` filter alongside the existing `iconify.lua` shortcode.
