### PR TITLE
feat: Add aria-hidden attribute for decorative icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: Add the `aria-hidden` attribute, marking an icon as decorative. `aria-hidden=true` omits `role`, `aria-label`, and `title` in HTML, and the `alt` text in Typst, so an icon placed beside visible text no longer doubles the accessible name of the surrounding link. It is a shortcode attribute only, with no document-level default.
+
+### Documentation
+
+- docs: Mark the documentation website's own footer icons decorative, so the two footer links are announced as "Quarto" and "Sponsor" rather than "Quarto Quarto" and "Heart Sponsor".
+
 ## 4.0.1 (2026-08-01)
 
 ### Bug Fixes

--- a/_extensions/iconify/_schema.yml
+++ b/_extensions/iconify/_schema.yml
@@ -118,6 +118,12 @@ shortcodes:
       title:
         type: string
         description: "Title attribute for the icon tooltip."
+      aria-hidden:
+        type: string
+        description: "Marks the icon as decorative, omitting role, aria-label and title so assistive technology skips it. Use when visible text beside the icon already carries the meaning."
+        enum:
+          - "true"
+          - "false"
       fallback:
         type: string
         description: "Text or emoji shown when the icon cannot be loaded (e.g. unknown name, offline, CDN unreachable)."
@@ -166,6 +172,12 @@ shortcodes:
       title:
         type: string
         description: "Title attribute for the icon tooltip."
+      aria-hidden:
+        type: string
+        description: "Marks the icon as decorative, omitting role, aria-label and title so assistive technology skips it."
+        enum:
+          - "true"
+          - "false"
       fallback:
         type: string
         description: "Text or emoji shown when the icon cannot be loaded."

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -172,6 +172,38 @@ local function is_valid_iconify_name(value)
   return value:match('^[a-z0-9-]+$') ~= nil
 end
 
+--- Resolve the `aria-hidden` attribute, which marks an icon as decorative.
+--- A decorative icon carries no `role`, `aria-label` or `title`, so assistive
+--- technology skips it entirely. Read from the shortcode arguments alone:
+--- whether an icon is decorative depends on whether visible text sits beside
+--- that icon, which no document-level default can know.
+--- Accepts only 'true' and 'false'; anything else is ignored, and warns when
+--- `warn` is set, so a typo cannot silently strip an icon's accessible name.
+--- The `quarto` shortcode resolves the value without warning, since the icon
+--- it builds passes through this function again on the way out.
+--- @param kwargs table<string, any> Key-value options for the icon
+--- @param warn boolean Whether to warn about an unrecognised value
+--- @return boolean
+local function is_decorative(kwargs, warn)
+  --- @type string
+  local value = str.stringify(kwargs['aria-hidden'])
+  if str.is_empty(value) or value == 'false' then
+    return false
+  end
+  if value == 'true' then
+    return true
+  end
+  if warn then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring invalid aria-hidden value "' .. value .. '". ' ..
+      'Use aria-hidden="true" to mark an icon as decorative, or "false". ' ..
+      'The icon keeps its accessible name.'
+    )
+  end
+  return false
+end
+
 --- Get an iconify option from arguments or metadata.
 --- Resolution order: positional/named kwargs first, then nested
 --- `extensions.iconify.<key>`, then the deprecated top-level `iconify.<key>`
@@ -208,10 +240,11 @@ end
 --- @param icon string Resolved icon name
 --- @param set string Resolved icon set
 --- @param default_label string Fallback accessibility label
+--- @param decorative boolean Whether the icon is marked decorative
 --- @param kwargs table<string, any> Key-value options for the icon
 --- @param meta table<string, any> Document metadata
 --- @return any Pandoc RawInline (Typst), Str (fallback) or Null
-local function render_typst(icon, set, default_label, kwargs, meta)
+local function render_typst(icon, set, default_label, decorative, kwargs, meta)
   --- @type string
   local size_raw = resolve_size_value(get_iconify_options('size', kwargs, meta))
   --- @type string|nil
@@ -246,10 +279,15 @@ local function render_typst(icon, set, default_label, kwargs, meta)
   local rotate = get_iconify_options('rotate', kwargs, meta)
   if not str.is_empty(rotate) then params.rotate = rotate end
 
+  --- A decorative icon carries no `alt`, which the typst module omits when the
+  --- value is empty.
   --- @type string
-  local alt = str.stringify(kwargs['label'])
-  if str.is_empty(alt) then alt = str.stringify(kwargs['title']) end
-  if str.is_empty(alt) then alt = default_label end
+  local alt = ''
+  if not decorative then
+    alt = str.stringify(kwargs['label'])
+    if str.is_empty(alt) then alt = str.stringify(kwargs['title']) end
+    if str.is_empty(alt) then alt = default_label end
+  end
 
   --- @type string
   local inline = get_iconify_options('inline', kwargs, meta)
@@ -347,8 +385,20 @@ local function iconify(args, kwargs, meta)
   --- @type string
   local default_label = 'Icon ' .. icon .. ' from ' .. set .. ' Iconify.design set.'
 
+  --- @type boolean
+  local decorative = is_decorative(kwargs, true)
+  if decorative and (not str.is_empty(str.stringify(kwargs['label'])) or
+        not str.is_empty(str.stringify(kwargs['title']))) then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Icon "' .. set .. ':' .. icon .. '" sets aria-hidden="true" together ' ..
+      'with label or title. A decorative icon carries neither, so both are ' ..
+      'discarded. Drop aria-hidden to keep them.'
+    )
+  end
+
   if is_typst then
-    return render_typst(icon, set, default_label, kwargs, meta)
+    return render_typst(icon, set, default_label, decorative, kwargs, meta)
   end
 
   ensure_html_deps()
@@ -369,23 +419,31 @@ local function iconify(args, kwargs, meta)
     attributes = attributes .. ' style="' .. style .. '"'
   end
 
+  --- A decorative icon is hidden from assistive technology, so it carries
+  --- `aria-hidden` in place of `role`, and neither `aria-label` nor `title`.
   --- @type string
-  local aria_label = str.stringify(kwargs['label'])
-  if str.is_empty(aria_label) then
-    aria_label = ' aria-label="' .. default_label .. '"'
+  local role = ' role="img"'
+  if decorative then
+    role = ' aria-hidden="true"'
   else
-    aria_label = ' aria-label="' .. aria_label .. '"'
-  end
+    --- @type string
+    local aria_label = str.stringify(kwargs['label'])
+    if str.is_empty(aria_label) then
+      aria_label = ' aria-label="' .. default_label .. '"'
+    else
+      aria_label = ' aria-label="' .. aria_label .. '"'
+    end
 
-  --- @type string
-  local title = str.stringify(kwargs['title'])
-  if str.is_empty(title) then
-    title = ' title="' .. default_label .. '"'
-  else
-    title = ' title="' .. title .. '"'
-  end
+    --- @type string
+    local title = str.stringify(kwargs['title'])
+    if str.is_empty(title) then
+      title = ' title="' .. default_label .. '"'
+    else
+      title = ' title="' .. title .. '"'
+    end
 
-  attributes = attributes .. aria_label .. title
+    attributes = attributes .. aria_label .. title
+  end
 
   --- @type string
   local width = get_iconify_options('width', kwargs, meta)
@@ -427,10 +485,17 @@ local function iconify(args, kwargs, meta)
 
   if not str.is_empty(fallback) then
     ensure_fallback_runtime()
+    --- The fallback text is a sibling of the icon rather than a descendant,
+    --- so hiding the icon alone would leave the revealed text announced.
+    --- @type string
+    local wrapper_hidden = ''
+    if decorative then
+      wrapper_hidden = ' aria-hidden="true"'
+    end
     return pandoc.RawInline(
       'html',
-      '<span class="iconify-icon-wrapper" data-iconify-fallback>' ..
-      '<iconify-icon role="img"' .. attributes .. '></iconify-icon>' ..
+      '<span class="iconify-icon-wrapper" data-iconify-fallback' .. wrapper_hidden .. '>' ..
+      '<iconify-icon' .. role .. attributes .. '></iconify-icon>' ..
       '<span class="iconify-icon-fallback" hidden>' .. fallback .. '</span>' ..
       '</span>'
     )
@@ -438,7 +503,7 @@ local function iconify(args, kwargs, meta)
 
   return pandoc.RawInline(
     'html',
-    '<iconify-icon role="img"' .. attributes .. '></iconify-icon>'
+    '<iconify-icon' .. role .. attributes .. '></iconify-icon>'
   )
 end
 
@@ -452,8 +517,12 @@ local function iconify_quarto(args, kwargs, meta)
   local quarto_args = { 'simple-icons:quarto' }
   --- @type table<string, any>
   local quarto_kwargs = kwargs or {}
-  quarto_kwargs['label'] = 'Quarto icon'
-  quarto_kwargs['title'] = 'Quarto icon'
+  -- A decorative icon carries neither, and setting them here would re-introduce
+  -- exactly what `aria-hidden` removes.
+  if not is_decorative(quarto_kwargs, false) then
+    quarto_kwargs['label'] = 'Quarto icon'
+    quarto_kwargs['title'] = 'Quarto icon'
+  end
   --- @type string
   local quarto_colour = 'color:#74aadb;'
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -63,10 +63,13 @@ website:
       - href: changelog.qmd
         text: "Changelog"
   page-footer:
+    # Both icons sit inside a link that already names itself, so they are
+    # decorative: labelling them would have the link announced as "Quarto
+    # Quarto" and "Heart Sponsor", with a browser tooltip over each.
     left: |
-      Powered by [{{< iconify simple-icons:quarto title="Quarto" label="Quarto" >}} Quarto](https://quarto.org).
+      Powered by [{{< iconify simple-icons:quarto aria-hidden=true >}} Quarto](https://quarto.org).
     center: |
-      &copy; []{#current-year} [Mickaël Canouil](https://mickael.canouil.fr). [{{< iconify octicon:heart-fill-16 title="Heart" label="Heart" >}} Sponsor](https://github.com/sponsors/mcanouil?o=esb).
+      &copy; []{#current-year} [Mickaël Canouil](https://mickael.canouil.fr). [{{< iconify octicon:heart-fill-16 aria-hidden=true >}} Sponsor](https://github.com/sponsors/mcanouil?o=esb).
     right: |
       Licence: [MIT](https://github.com/mcanouil/quarto-iconify?tab=MIT-1-ov-file#readme).
 

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -53,7 +53,7 @@ The `color` attribute is for Typst output, where the colour is baked into the re
 
 ## Accessibility
 
-Every icon is announced, so label every icon.
+An icon is announced by default, so label every icon that carries meaning and hide every icon that does not.
 
 ```markdown
 {{{< iconify octicon:alert-16 label="Warning" title="Warning" >}}}
@@ -67,8 +67,27 @@ Left unset, both fall back to a generated string naming the set and the file:
 | --- | --- |
 | `{{{< iconify octicon:alert-16 >}}}` | `Icon alert-16 from octicon Iconify.design set.` |
 | `{{{< iconify octicon:alert-16 label="Warning" >}}}` | `Warning` |
+| `{{{< iconify octicon:alert-16 aria-hidden=true >}}}` | Nothing. The icon is skipped. |
 
-: What a screen reader reads out, with and without a label. {.striped .hover tbl-colwidths="[55,45]"}
+: What a screen reader reads out, with a label, without one, and hidden. {.striped .hover tbl-colwidths="[55,45]"}
+
+### An icon beside its own label
+
+An icon inside a link that already has visible text says nothing the text does not.
+Labelled, it is announced twice over and pops a tooltip; hidden, the link reads as written:
+
+```markdown
+[{{{< iconify octicon:heart-fill-16 aria-hidden=true >}}} Sponsor](https://github.com/sponsors/mcanouil)
+```
+
+[{{< iconify octicon:heart-fill-16 aria-hidden=true >}} Sponsor](https://github.com/sponsors/mcanouil)
+
+| Source | Link announced as |
+| --- | --- |
+| `[{{{< iconify octicon:heart-fill-16 label="Heart" >}}} Sponsor](…)` | `Heart Sponsor` |
+| `[{{{< iconify octicon:heart-fill-16 aria-hidden=true >}}} Sponsor](…)` | `Sponsor` |
+
+: The accessible name of the surrounding link. {.striped .hover tbl-colwidths="[62,38]"}
 
 ## The Quarto icon
 

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -28,7 +28,7 @@ A set or icon name outside the pattern Iconify enforces, lowercase letters and d
 ```
 
 Draws `simple-icons:quarto` in the Quarto blue, `#74aadb`: {{< quarto >}}.
-It takes the same attributes as `iconify`, except that `label` and `title` are fixed to `Quarto icon`.
+It takes the same attributes as `iconify`, except that `label` and `title` are fixed to `Quarto icon`, or dropped entirely under `aria-hidden="true"`.
 A `style` attribute is kept, with its `color` replaced by the Quarto blue.
 
 ## Attributes
@@ -45,6 +45,7 @@ A `style` attribute is kept, with its `color` replaced by the Quarto blue.
 | `style` | Extra inline CSS, written before the `font-size` that `size` generates. |
 | `label` | The `aria-label`. Replaces the generated one. |
 | `title` | The tooltip. Replaces the generated one. |
+| `aria-hidden` | `true` marks the icon decorative, dropping `role`, `aria-label`, and `title`. |
 | `fallback` | Text or an emoji revealed when the icon fails to load. |
 
 : Attributes accepted on both shortcodes. {.striped .hover tbl-colwidths="[22,78]"}
@@ -66,17 +67,29 @@ Anything else warns and leaves the size alone.
 
 ### Accessibility
 
-Every icon carries `role="img"`, an `aria-label`, and a `title`.
-Left unset, both read `Icon <name> from <set> Iconify.design set.`, which a screen reader announces verbatim.
+An icon carries `role="img"`, an `aria-label`, and a `title` by default.
+Left unset, both read `Icon <name> from <set> Iconify.design set.`, which a screen reader announces verbatim, so set `label` on every icon that carries meaning.
+
+An icon that carries no meaning of its own is decorative, and takes `aria-hidden="true"` instead:
+
+```markdown
+[{{{< iconify octicon:heart-fill-16 aria-hidden=true >}}} Sponsor](https://github.com/sponsors/mcanouil)
+```
+
+That icon is emitted as `<iconify-icon aria-hidden="true" …>`, with no `role`, no `aria-label`, and no `title`, so it is skipped rather than announced and no tooltip appears over it.
+Without it the link above is announced as "Heart Sponsor" and the word beside the icon is read twice.
 
 ::: {.callout-note}
-Set `label` on every icon that carries meaning, and on every icon that does not.
-There is no decorative mode: an icon with no `label` is announced by its set and file name rather than skipped.
+Use `aria-hidden` only where visible text beside the icon already says what the icon says.
+An icon standing alone, such as a bare link to a social profile, is the meaning and needs a `label`.
 :::
+
+`aria-hidden` takes `true` or `false`; any other value warns and leaves the icon announced.
+Setting it alongside `label` or `title` warns and discards both, since a decorative icon carries neither.
 
 ## Document defaults
 
-Every attribute except `label` and `title` has a matching option, applied to all icons:
+Every attribute except `label`, `title`, and `aria-hidden` has a matching option, applied to all icons:
 
 ```yaml
 extensions:
@@ -136,9 +149,12 @@ With no `color`, a `color:` declaration inside `style` is read instead, so one `
 `size` becomes the image height, so the icon scales with the surrounding text.
 Typst accepts `em`, `pt`, `cm`, `mm`, `in`, and `%`; any other unit warns and falls back to `1em`.
 
+`label`, then `title`, then the generated string become the image `alt`.
+`aria-hidden="true"` drops the `alt` instead, so one shortcode means the same thing in both outputs.
+
 ## Limitations
 
 - HTML and Typst only. The HTML path requires a format that runs JavaScript, so EPUB renders nothing.
 - In HTML the icon is fetched from the Iconify CDN at page load unless preloaded, so a reader offline sees the `fallback`.
 - `color` is Typst only; in HTML use `style` or the surrounding text colour.
-- `label` and `title` take no document default; set them per icon.
+- `label`, `title`, and `aria-hidden` take no document default; set them per icon. Whether an icon is decorative depends on the text beside that icon, which a document-wide setting cannot know.

--- a/example.qmd
+++ b/example.qmd
@@ -66,11 +66,11 @@ Iconify API provides additional attributes: <https://docs.iconify.design/iconify
 Currently, this extension supports the following attributes:
 
 ```markdown
-{{{< iconify <set=...> <icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> <inline=...> <mode=...> <style=...> >}}}
+{{{< iconify <set=...> <icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> <aria-hidden=...> <inline=...> <mode=...> <style=...> >}}}
 ```
 
 ```markdown
-{{{< iconify <set:icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> <inline=...> <mode=...> <style=...> >}}}
+{{{< iconify <set:icon> <size=...> <width=...> <height=...> <flip=...> <rotate=...> <title=...> <label=...> <aria-hidden=...> <inline=...> <mode=...> <style=...> >}}}
 ```
 
 #### Available Attributes
@@ -88,6 +88,8 @@ Currently, this extension supports the following attributes:
 - `title`: Tooltip text for the icon. Default: `Icon <icon> from <set> Iconify.design set.`.
 
 - `label` (i.e., `aria-label`): Accessibility label for screen readers. Default: `Icon <icon> from <set> Iconify.design set.`.
+
+- `aria-hidden`: Boolean attribute (`true` or `false`). When `true`, the icon is decorative: `role`, `aria-label`, and `title` are all omitted, so assistive technology skips it. Use it when visible text beside the icon already carries the meaning, such as an icon inside a link that is already labelled. Default is `false`.
 
 - `inline`: Boolean attribute (`true` or `false`). When `true`, the icon is displayed inline with text. Default is `true`.
 
@@ -115,7 +117,7 @@ extensions:
 
 :::: {.callout-note}
 
-The attributes `icon`, `title`, and `label` must be defined in the shortcode itself and cannot have default values in the YAML header.
+The attributes `icon`, `title`, `label`, and `aria-hidden` must be defined in the shortcode itself and cannot have default values in the YAML header.
 
 :::
 


### PR DESCRIPTION
An icon placed beside visible text inside a link doubled the link's accessible name and put a browser tooltip over it. A footer written as `[{{< iconify octicon:heart-fill-16 title="Heart" label="Heart" >}} Sponsor](...)` was announced as "Heart Sponsor".

No combination of the existing attributes could prevent it. `role="img"` was hardcoded into both emission paths, outside the attribute string, so nothing an author passed could reach it, and `aria-label` and `title` were always emitted, falling back to a generated string naming the icon set and file.

`aria-hidden="true"` now marks an icon decorative. In HTML it emits `aria-hidden` in place of `role` and omits `aria-label` and `title`; in Typst it omits the image `alt` text. Where a `fallback` is set, the attribute also goes on the wrapper span, since the fallback text the runtime reveals is a sibling of the icon rather than a descendant.

It is a shortcode attribute only, with no `extensions.iconify` counterpart: whether an icon is decorative depends on the text sitting beside that icon, which a document-wide default cannot know.

Setting it alongside `label` or `title` warns and discards both. Any value other than `true` or `false` warns and leaves the icon announced, so a typo cannot silently strip an accessible name. The `quarto` shortcode honours it too, skipping the `Quarto icon` label and title it otherwise fixes.

The documentation website's own footer icons adopt the attribute, taking the two footer links from "Quarto Quarto" and "Heart Sponsor" to "Quarto" and "Sponsor".

Verified by rendering: HTML and Typst output inspected across labelled, unset, decorative, `aria-hidden=false`, quoted and unquoted, invalid-value, contradictory, and fallback cases, for both shortcodes. The accessible-name computation in a browser has not been checked.