### PR TITLE
fix: recover unquoted attributes in a metadata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Recover an attribute written without quotes inside a metadata field. Quarto reads a shortcode in `title:`, `subtitle:`, or a navbar `text:` with a different parser from the one it uses for the body, and that parser demotes an unquoted `key=value` to a positional argument. `{{< iconify octicon:heart-fill-16 aria-hidden=true >}}` in a `title:` was therefore announced instead of skipped. The pair is now folded back into the attributes, so one shortcode means the same thing in a metadata field as in the body.
+
 ## 4.1.0 (2026-08-04)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- fix: Recover an attribute written without quotes inside a metadata field. Quarto reads a shortcode in `title:`, `subtitle:`, or a navbar `text:` with a different parser from the one it uses for the body, and that parser demotes an unquoted `key=value` to a positional argument. `{{< iconify octicon:heart-fill-16 aria-hidden=true >}}` in a `title:` was therefore announced instead of skipped. The pair is now folded back into the attributes, so one shortcode means the same thing in a metadata field as in the body.
+- fix: Recover an attribute written without quotes inside a metadata field. Quarto reads a shortcode in `title:`, `subtitle:`, or a navbar `text:` with a different parser from the one it uses for the body, and that parser demotes an unquoted `key=value` to a positional argument. `{{< iconify octicon:heart-fill-16 aria-hidden='true' >}}` in a `title:` was therefore announced instead of skipped. The pair is now folded back into the attributes, so one shortcode means the same thing in a metadata field as in the body.
 
 ## 4.1.0 (2026-08-04)
 

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -204,6 +204,37 @@ local function is_decorative(kwargs, warn)
   return false
 end
 
+--- Fold `key=value` positional arguments back into `kwargs`.
+--- Quarto parses body shortcodes with `lpegshortcode.lua`, which reads an
+--- unquoted `key=value`, but a shortcode in a metadata field (`title:`,
+--- `subtitle:`, a navbar `text:`) goes through `astshortcode.lua`, which reads
+--- a key only when the value is quoted and otherwise hands the whole token
+--- over as a positional argument. Recovering the pair here is what makes one
+--- shortcode mean the same thing in a metadata field as in the body; drop this
+--- once Quarto's metadata parser matches its body parser.
+--- An explicitly parsed entry always wins, and an icon or set name cannot
+--- contain `=`, so the icon arguments are never captured.
+--- Pandoc splits on whitespace before the extension sees the shortcode, so an
+--- unquoted value carrying a space (`label=Hello world`) recovers its first
+--- token alone. Quoting the value remains the documented form.
+--- @param args table<integer, any> Icon arguments (icon set and name)
+--- @param kwargs table<string, any> Key-value options for the icon
+--- @return table<integer, any> Icon arguments with the recovered pairs removed
+local function recover_kwargs(args, kwargs)
+  --- @type table<integer, any>
+  local positional = {}
+  for _, arg in ipairs(args) do
+    --- @type string, string
+    local key, value = string.match(str.stringify(arg), '^([%a][%w%-]*)=(.*)$')
+    if key == nil then
+      table.insert(positional, arg)
+    elseif str.is_empty(str.stringify(kwargs[key])) then
+      kwargs[key] = value
+    end
+  end
+  return positional
+end
+
 --- Get an iconify option from arguments or metadata.
 --- Resolution order: positional/named kwargs first, then nested
 --- `extensions.iconify.<key>`, then the deprecated top-level `iconify.<key>`
@@ -319,6 +350,8 @@ end
 --- @param meta table<string, any> Document metadata
 --- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
 local function iconify(args, kwargs, meta)
+  args = recover_kwargs(args, kwargs)
+
   -- HTML (excluding epub which will not host the Web Component) renders the
   -- Web Component; Typst renders a cached SVG. Every other format renders
   -- nothing.
@@ -508,7 +541,7 @@ local function iconify(args, kwargs, meta)
 end
 
 --- Render Quarto icon using the iconify function with preset styling.
---- @param args table<integer, any> Icon arguments (ignored as we're using a preset icon)
+--- @param args table<integer, any> Icon arguments (the icon is a preset, so these are read only for attributes a metadata field left unparsed)
 --- @param kwargs table<string, any>|nil Key-value options that might override default styling
 --- @param meta table<string, any> Document metadata
 --- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
@@ -517,6 +550,7 @@ local function iconify_quarto(args, kwargs, meta)
   local quarto_args = { 'simple-icons:quarto' }
   --- @type table<string, any>
   local quarto_kwargs = kwargs or {}
+  recover_kwargs(args, quarto_kwargs)
   -- A decorative icon carries neither, and setting them here would re-introduce
   -- exactly what `aria-hidden` removes.
   if not is_decorative(quarto_kwargs, false) then

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -67,7 +67,7 @@ Left unset, both fall back to a generated string naming the set and the file:
 | --- | --- |
 | `{{{< iconify octicon:alert-16 >}}}` | `Icon alert-16 from octicon Iconify.design set.` |
 | `{{{< iconify octicon:alert-16 label="Warning" >}}}` | `Warning` |
-| `{{{< iconify octicon:alert-16 aria-hidden=true >}}}` | Nothing. The icon is skipped. |
+| `{{{< iconify octicon:alert-16 aria-hidden='true' >}}}` | Nothing. The icon is skipped. |
 
 : What a screen reader reads out, with a label, without one, and hidden. {.striped .hover tbl-colwidths="[55,45]"}
 
@@ -77,15 +77,15 @@ An icon inside a link that already has visible text says nothing the text does n
 Labelled, it is announced twice over and pops a tooltip; hidden, the link reads as written:
 
 ```markdown
-[{{{< iconify octicon:heart-fill-16 aria-hidden=true >}}} Sponsor](https://github.com/sponsors/mcanouil)
+[{{{< iconify octicon:heart-fill-16 aria-hidden='true' >}}} Sponsor](https://github.com/sponsors/mcanouil)
 ```
 
-[{{< iconify octicon:heart-fill-16 aria-hidden=true >}} Sponsor](https://github.com/sponsors/mcanouil)
+[{{< iconify octicon:heart-fill-16 aria-hidden='true' >}} Sponsor](https://github.com/sponsors/mcanouil)
 
 | Source | Link announced as |
 | --- | --- |
 | `[{{{< iconify octicon:heart-fill-16 label="Heart" >}}} Sponsor](…)` | `Heart Sponsor` |
-| `[{{{< iconify octicon:heart-fill-16 aria-hidden=true >}}} Sponsor](…)` | `Sponsor` |
+| `[{{{< iconify octicon:heart-fill-16 aria-hidden='true' >}}} Sponsor](…)` | `Sponsor` |
 
 : The accessible name of the surrounding link. {.striped .hover tbl-colwidths="[62,38]"}
 

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -73,7 +73,7 @@ Left unset, both read `Icon <name> from <set> Iconify.design set.`, which a scre
 An icon that carries no meaning of its own is decorative, and takes `aria-hidden="true"` instead:
 
 ```markdown
-[{{{< iconify octicon:heart-fill-16 aria-hidden=true >}}} Sponsor](https://github.com/sponsors/mcanouil)
+[{{{< iconify octicon:heart-fill-16 aria-hidden='true' >}}} Sponsor](https://github.com/sponsors/mcanouil)
 ```
 
 That icon is emitted as `<iconify-icon aria-hidden="true" …>`, with no `role`, no `aria-label`, and no `title`, so it is skipped rather than announced and no tooltip appears over it.

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -87,6 +87,17 @@ An icon standing alone, such as a bare link to a social profile, is the meaning 
 `aria-hidden` takes `true` or `false`; any other value warns and leaves the icon announced.
 Setting it alongside `label` or `title` warns and discards both, since a decorative icon carries neither.
 
+## Icons in metadata
+
+A shortcode works in a metadata field as well as in the body, so a page title, a subtitle, or a navbar entry can carry an icon:
+
+```yaml
+title: '{{{< iconify octicon:megaphone-24 aria-hidden="true" >}}} Blog'
+```
+
+Quote the attribute value where you can, as above.
+Quarto reads metadata shortcodes with a different parser from the one it uses for the body, and that parser only recognises `key="value"`; an unquoted value is recovered afterwards, which works for a single word but keeps only the first word of a value carrying a space.
+
 ## Document defaults
 
 Every attribute except `label`, `title`, and `aria-hidden` has a matching option, applied to all icons:


### PR DESCRIPTION
## Problem

A shortcode in a metadata field loses any attribute whose value is not quoted.

```yaml
title: '{{< iconify octicon:heart-fill-16 aria-hidden=true >}} Blog'
```

```html
<!-- before -->
<iconify-icon role="img" inline="" icon="octicon:heart-fill-16"
  aria-label="Icon heart-fill-16 from octicon Iconify.design set."
  title="Icon heart-fill-16 from octicon Iconify.design set.">
<!-- after -->
<iconify-icon aria-hidden="true" inline="" icon="octicon:heart-fill-16">
```

The same shortcode in the body has always been correct.

## Cause

Quarto uses two shortcode parsers.
The body goes through `lpegshortcode.lua`, which reads an unquoted `key=value`.
A metadata field goes through `normalize.lua` then `astshortcode.lua`, which reads a key only when Pandoc emits a `Str` ending in `=`, and that happens only when the value is quoted.
With an unquoted value the whole token is handed over as a positional argument instead:

```text
args   = {"octicon:heart-fill-16", "aria-hidden=true"}
kwargs = {}
```

`is_decorative()` then reads the empty-Inlines default and returns `false`, silently.
`label` and `title` are lost the same way; `size` and `inline` survive only because they fall back to document metadata.

## Fix

`recover_kwargs()` folds any `key=value` positional back into `kwargs` before anything reads them, in both `iconify` and `quarto` (the latter reads `kwargs` before delegating).
An explicitly parsed entry always wins, and an icon or set name cannot contain `=`, so the icon arguments are never captured.

Recovery is silent: the author wrote valid shortcode syntax, so there is nothing for them to fix.
The comment names `astshortcode.lua` so the workaround can be dropped if Quarto's two parsers converge.

Known limitation, documented: Pandoc splits on whitespace first, so an unquoted value carrying a space keeps only its first token. Quoting remains the recommended form.

## Verification

Rendered a document exercising every combination; all correct, no warnings.

| Case | Result |
| --- | --- |
| `title:` unquoted `aria-hidden=true` | decorative |
| `subtitle:` `{{< quarto aria-hidden=true >}}` | decorative |
| `description:` unquoted `aria-hidden=false` | announced |
| `abstract:` `octicon heart-fill-16 label=Recovered` | correct icon, `aria-label="Recovered"` |
| all eight body cases | unchanged |
| `{{< iconify octicon heart-fill-16 >}}` | correct icon, positional not eaten |

Typst output checked on the same document: decorative icons drop `alt`, the rest keep it.
`example.qmd` and the `docs/` site both render clean.