### PR TITLE
fix: strip quote marks from a shortcode attribute value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Read a quoted attribute value in a `page-footer:` entry without warning. Quarto expands a shortcode written in a text or attribute string with a parser that hands the value over with its quote marks still attached, so `aria-hidden='true'` arrived as `'true'` and was rejected as invalid. A surrounding quote pair is now stripped when the value is read, so `aria-hidden=true`, `aria-hidden='true'`, and `aria-hidden="true"` mean the same thing wherever a shortcode is written. The same warning affected `size` and every other attribute read the same way.
+
 ## 4.1.1 (2026-08-07)
 
 ### Bug Fixes

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -172,6 +172,27 @@ local function is_valid_iconify_name(value)
   return value:match('^[a-z0-9-]+$') ~= nil
 end
 
+--- Read an attribute value with a surrounding quote pair removed.
+--- Quarto's body parser strips those quotes before the value reaches the
+--- shortcode, but the parser it uses for a text or attribute string (a
+--- `page-footer:` entry, for instance) hands the raw token over instead, so
+--- `aria-hidden='true'` arrives as the five-character string `'true'`.
+--- Stripping here is what makes a quoted and an unquoted value mean the same
+--- thing in every context; drop it once Quarto's parsers agree.
+--- @param kwargs table<string, any> Key-value options for the icon
+--- @param key string The attribute name to read
+--- @return string
+local function attr_value(kwargs, key)
+  --- @type string
+  local value = str.stringify(kwargs[key])
+  --- @type string
+  local quote = value:sub(1, 1)
+  if #value > 1 and (quote == '"' or quote == "'") and value:sub(-1) == quote then
+    return value:sub(2, -2)
+  end
+  return value
+end
+
 --- Resolve the `aria-hidden` attribute, which marks an icon as decorative.
 --- A decorative icon carries no `role`, `aria-label` or `title`, so assistive
 --- technology skips it entirely. Read from the shortcode arguments alone:
@@ -186,7 +207,7 @@ end
 --- @return boolean
 local function is_decorative(kwargs, warn)
   --- @type string
-  local value = str.stringify(kwargs['aria-hidden'])
+  local value = attr_value(kwargs, 'aria-hidden')
   if str.is_empty(value) or value == 'false' then
     return false
   end
@@ -245,7 +266,7 @@ end
 --- @return string The option value as a string
 local function get_iconify_options(x, arg, meta)
   --- @type string
-  local arg_value = str.stringify(arg[x])
+  local arg_value = attr_value(arg, x)
 
   if not str.is_empty(arg_value) then
     return arg_value
@@ -315,8 +336,8 @@ local function render_typst(icon, set, default_label, decorative, kwargs, meta)
   --- @type string
   local alt = ''
   if not decorative then
-    alt = str.stringify(kwargs['label'])
-    if str.is_empty(alt) then alt = str.stringify(kwargs['title']) end
+    alt = attr_value(kwargs, 'label')
+    if str.is_empty(alt) then alt = attr_value(kwargs, 'title') end
     if str.is_empty(alt) then alt = default_label end
   end
 
@@ -420,8 +441,8 @@ local function iconify(args, kwargs, meta)
 
   --- @type boolean
   local decorative = is_decorative(kwargs, true)
-  if decorative and (not str.is_empty(str.stringify(kwargs['label'])) or
-        not str.is_empty(str.stringify(kwargs['title']))) then
+  if decorative and (not str.is_empty(attr_value(kwargs, 'label')) or
+        not str.is_empty(attr_value(kwargs, 'title'))) then
     log.log_warning(
       EXTENSION_NAME,
       'Icon "' .. set .. ':' .. icon .. '" sets aria-hidden="true" together ' ..
@@ -460,7 +481,7 @@ local function iconify(args, kwargs, meta)
     role = ' aria-hidden="true"'
   else
     --- @type string
-    local aria_label = str.stringify(kwargs['label'])
+    local aria_label = attr_value(kwargs, 'label')
     if str.is_empty(aria_label) then
       aria_label = ' aria-label="' .. default_label .. '"'
     else
@@ -468,7 +489,7 @@ local function iconify(args, kwargs, meta)
     end
 
     --- @type string
-    local title = str.stringify(kwargs['title'])
+    local title = attr_value(kwargs, 'title')
     if str.is_empty(title) then
       title = ' title="' .. default_label .. '"'
     else
@@ -562,7 +583,7 @@ local function iconify_quarto(args, kwargs, meta)
 
   if not str.is_empty(quarto_kwargs['style']) then
     --- @type string
-    local style = str.stringify(quarto_kwargs['style'])
+    local style = attr_value(quarto_kwargs, 'style')
     if string.match(style, 'color:[^;]+;') then
       quarto_kwargs['style'] = string.gsub(style, 'color:[^;]+;', quarto_colour)
     else

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -95,8 +95,8 @@ A shortcode works in a metadata field as well as in the body, so a page title, a
 title: '{{{< iconify octicon:megaphone-24 aria-hidden="true" >}}} Blog'
 ```
 
-Quote the attribute value where you can, as above.
-Quarto reads metadata shortcodes with a different parser from the one it uses for the body, and that parser only recognises `key="value"`; an unquoted value is recovered afterwards, which works for a single word but keeps only the first word of a value carrying a space.
+A quoted and an unquoted value mean the same thing, so `aria-hidden="true"`, `aria-hidden='true'`, and `aria-hidden=true` are interchangeable.
+Quote a value that carries a space, such as `label="Latest news"`: Quarto reads metadata shortcodes with a different parser from the one it uses for the body, and an unquoted value is recovered from its first token alone, so every word after the first is lost.
 
 ## Document defaults
 


### PR DESCRIPTION
Quarto expands a shortcode written in a text or attribute string, such as a `page-footer:` entry, with a parser that hands the attribute value over with its quote marks still attached. `aria-hidden='true'` therefore arrived as the five-character string `'true'` and was rejected as invalid, and `size='2em'` was rejected the same way. The rendered output was already correct, because a later pass re-expands the shortcode with clean values, so the only symptom was warning noise: the documentation site emitted eleven warnings on every render.

An attribute value is now read through a helper that removes a matching surrounding quote pair, mirroring what Quarto's own body parser does. `aria-hidden=true`, `aria-hidden='true'`, and `aria-hidden="true"` now mean the same thing wherever a shortcode is written, and the same applies to every other attribute.

The reference page no longer advises quoting for its own sake, and keeps the caveat that a value carrying a space has to be quoted in a metadata field.

Verified by rendering `docs/` (eleven iconify warnings before, none after) and `example.qmd` to HTML and Typst, and by a website project exercising all three quoting forms in `page-footer:`, which now produce identical markup with no warnings.