### PR TITLE
fix: escape attribute values written into the HTML output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- fix: Escape an attribute value written into the HTML output. `label`, `title`, `style`, `width`, `height`, `flip`, `rotate`, and the icon name were concatenated into double-quoted attributes as they stood, so a value carrying a `"` closed its attribute early and the rest was read as markup: `title='" onload="alert(1)'` emitted a working event handler. The `fallback` text, documented as text or an emoji, was likewise written as raw HTML. Both are now escaped. Icons written the documented way render byte for byte as before.
+
 - fix: Read a quoted attribute value in a `page-footer:` entry without warning. Quarto expands a shortcode written in a text or attribute string with a parser that hands the value over with its quote marks still attached, so `aria-hidden='true'` arrived as `'true'` and was rejected as invalid. A surrounding quote pair is now stripped when the value is read, so `aria-hidden=true`, `aria-hidden='true'`, and `aria-hidden="true"` mean the same thing wherever a shortcode is written. The same warning affected `size` and every other attribute read the same way.
 
 ## 4.1.1 (2026-08-07)

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -130,6 +130,7 @@ local function resolve_size_value(size)
   if str.is_empty(size) then
     return ''
   end
+  --- @cast size string
   --- @type string|nil
   local mapped = SIZE_KEYWORDS[size]
   if mapped ~= nil then
@@ -191,6 +192,19 @@ local function attr_value(kwargs, key)
     return value:sub(2, -2)
   end
   return value
+end
+
+--- Build a single HTML attribute, escaping the value.
+--- Every value reaching this point is author-supplied and lands inside a
+--- double-quoted attribute, so an unescaped `"` would close the attribute
+--- early and let the rest of the value be read as markup. Going through one
+--- function rather than concatenating at each site is what keeps that from
+--- being forgotten as attributes are added.
+--- @param name string Attribute name
+--- @param value string Attribute value
+--- @return string The attribute, with a leading space
+local function html_attribute(name, value)
+  return ' ' .. name .. '="' .. str.escape_attribute(value) .. '"'
 end
 
 --- Resolve the `aria-hidden` attribute, which marks an icon as decorative.
@@ -458,7 +472,7 @@ local function iconify(args, kwargs, meta)
   ensure_html_deps()
 
   --- @type string
-  local attributes = ' icon="' .. set .. ':' .. icon .. '"'
+  local attributes = html_attribute('icon', set .. ':' .. icon)
 
   --- @type string
   local size = resolve_size(get_iconify_options('size', kwargs, meta))
@@ -466,11 +480,11 @@ local function iconify(args, kwargs, meta)
   local style = get_iconify_options('style', kwargs, meta)
 
   if str.is_empty(style) and not str.is_empty(size) then
-    attributes = attributes .. ' style="' .. size .. '"'
+    attributes = attributes .. html_attribute('style', size)
   elseif not str.is_empty(style) and not str.is_empty(size) then
-    attributes = attributes .. ' style="' .. style .. ';' .. size .. '"'
+    attributes = attributes .. html_attribute('style', style .. ';' .. size)
   elseif not str.is_empty(style) then
-    attributes = attributes .. ' style="' .. style .. '"'
+    attributes = attributes .. html_attribute('style', style)
   end
 
   --- A decorative icon is hidden from assistive technology, so it carries
@@ -483,41 +497,39 @@ local function iconify(args, kwargs, meta)
     --- @type string
     local aria_label = attr_value(kwargs, 'label')
     if str.is_empty(aria_label) then
-      aria_label = ' aria-label="' .. default_label .. '"'
-    else
-      aria_label = ' aria-label="' .. aria_label .. '"'
+      aria_label = default_label
     end
 
     --- @type string
     local title = attr_value(kwargs, 'title')
     if str.is_empty(title) then
-      title = ' title="' .. default_label .. '"'
-    else
-      title = ' title="' .. title .. '"'
+      title = default_label
     end
 
-    attributes = attributes .. aria_label .. title
+    attributes = attributes ..
+        html_attribute('aria-label', aria_label) ..
+        html_attribute('title', title)
   end
 
   --- @type string
   local width = get_iconify_options('width', kwargs, meta)
   if not str.is_empty(width) and str.is_empty(size) then
-    attributes = attributes .. ' width="' .. width .. '"'
+    attributes = attributes .. html_attribute('width', width)
   end
   --- @type string
   local height = get_iconify_options('height', kwargs, meta)
   if not str.is_empty(height) and str.is_empty(size) then
-    attributes = attributes .. ' height="' .. height .. '"'
+    attributes = attributes .. html_attribute('height', height)
   end
   --- @type string
   local flip = get_iconify_options('flip', kwargs, meta)
   if not str.is_empty(flip) then
-    attributes = attributes .. ' flip="' .. flip .. '"'
+    attributes = attributes .. html_attribute('flip', flip)
   end
   --- @type string
   local rotate = get_iconify_options('rotate', kwargs, meta)
   if not str.is_empty(rotate) then
-    attributes = attributes .. ' rotate="' .. rotate .. '"'
+    attributes = attributes .. html_attribute('rotate', rotate)
   end
 
   --- @type string
@@ -531,7 +543,7 @@ local function iconify(args, kwargs, meta)
   --- @type table<string, boolean>
   local valid_modes = { svg = true, style = true, bg = true, mask = true }
   if not str.is_empty(mode) and valid_modes[mode] then
-    attributes = attributes .. ' mode="' .. mode .. '"'
+    attributes = attributes .. html_attribute('mode', mode)
   end
 
   --- @type string
@@ -550,7 +562,9 @@ local function iconify(args, kwargs, meta)
       'html',
       '<span class="iconify-icon-wrapper" data-iconify-fallback' .. wrapper_hidden .. '>' ..
       '<iconify-icon' .. role .. attributes .. '></iconify-icon>' ..
-      '<span class="iconify-icon-fallback" hidden>' .. fallback .. '</span>' ..
+      --- The fallback is documented as text or an emoji, so it is escaped
+      --- rather than trusted as markup.
+      '<span class="iconify-icon-fallback" hidden>' .. str.escape_html(fallback) .. '</span>' ..
       '</span>'
     )
   end


### PR DESCRIPTION
Attribute values were concatenated straight into double-quoted HTML attributes, so a value carrying a `"` closed its attribute early and the rest was read as markup. `title='" onload="alert(1)'` emitted a working event handler on the rendered page, and `label`, `style`, `width`, `height`, `flip`, `rotate`, and the icon name all behaved the same way. The `fallback` text is documented as text or an emoji but was written as raw HTML, so it could carry a script element.

Attributes are now built through a single helper that escapes the value, using `escape_attribute` from the string module. Routing every attribute through one function also keeps the escaping from being forgotten as attributes are added. The fallback text is escaped as content with `escape_html`.

Values are author-supplied, so this matters most where a document is generated: a shortcode built from a listing, a data frame, or metadata from elsewhere could otherwise put an event handler on the page.

Verified by rendering a document exercising each attribute with an embedded `"`: every value now stays inside its attribute and the injected `<script>` is escaped. The icon markup for `example.qmd` is byte for byte identical to before the change, and `docs/` renders with no warnings.

Also narrows `size` after the emptiness guard in `resolve_size_value`, so the file type-checks without warnings.