### PR TITLE
fix: return a single value from escape_typst_string

### DIFF
--- a/_extensions/iconify/_modules/string.lua
+++ b/_extensions/iconify/_modules/string.lua
@@ -109,7 +109,7 @@ end
 --- @param text string The text to escape
 --- @return string The escaped text safe for Typst string literals
 function M.escape_typst_string(text)
-  return text:gsub('\\', '\\\\'):gsub('"', '\\"')
+  return (text:gsub('\\', '\\\\'):gsub('"', '\\"'))
 end
 
 --- Escape special Lua pattern characters for use in string.gsub.

--- a/_extensions/iconify/iconify-filter.lua
+++ b/_extensions/iconify/iconify-filter.lua
@@ -111,8 +111,9 @@ local function inject_preload(meta)
 end
 
 --- Pandoc Meta handler. Inject preload script for HTML output only.
---- @param meta table<string, any>
---- @return table<string, any>
+--- Quarto's language-server plugin rewrites a filter function's doc comment,
+--- adding `@param meta pandoc.Meta` and `@return pandoc.Meta|nil` without
+--- checking for an existing annotation, so declaring either here duplicates it.
 function Meta(meta)
   if quarto.doc.is_format('html:js') then
     inject_preload(meta)


### PR DESCRIPTION
Two findings from running `lua-language-server --check` over the extension, which now type-checks with no warnings.

`escape_typst_string` ended in `return text:gsub(...):gsub(...)`. `gsub` returns the result and a replacement count, and a tail return propagates both, so the function declared one return value and handed back two. Every call site concatenates the result, which truncates to the first value, so nothing was visibly wrong; used in a multi-value position it would have passed a stray integer along. The call is now parenthesised to truncate at the source, matching what `urlencode` in the typst module already does.

The `Meta` filter function carried hand-written `@param` and `@return` annotations. Quarto ships a language-server plugin (`lua-plugin/plugin.lua`) whose `OnSetText` rewrites any `function Meta(meta)` to insert `@param meta pandoc.Meta` and `@return pandoc.Meta|nil`, with no check for an existing annotation, so the hand-written pair became a duplicate parameter. The annotations are dropped and the reason recorded in the comment; the plugin supplies more precise types than the hand-written ones did.

No user-facing change, so no changelog entry. Verified by rendering `docs/` with no warnings and `example.qmd` to HTML and Typst.