### PR TITLE
fix: report an error when the iconify shortcode names no icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - feat: Add `color` as a document option, so a Typst icon colour can be set for the whole document rather than on each shortcode.
 - feat: Check the document configuration and each shortcode call against `_schema.yml`, reporting an unknown option, an unknown attribute, or a value outside the ones an option accepts.
 
+### Bug Fixes
+
+- fix: Report an error when the `iconify` shortcode names no icon. Such a call raised a Lua error that stopped the whole render, and `_schema.yml` now marks the first argument as required. (#87)
+
 ## 4.1.2 (2026-08-08)
 
 ### Bug Fixes

--- a/_extensions/iconify/_schema.yml
+++ b/_extensions/iconify/_schema.yml
@@ -82,6 +82,7 @@ shortcodes:
       - name: set-or-icon
         type: string
         required: true
+        examples: ["mdi:home"]
         description: "Icon set name, or the combined 'set:icon' format."
       - name: icon
         type: string

--- a/_extensions/iconify/_schema.yml
+++ b/_extensions/iconify/_schema.yml
@@ -81,6 +81,7 @@ shortcodes:
     arguments:
       - name: set-or-icon
         type: string
+        required: true
         description: "Icon set name, or the combined 'set:icon' format."
       - name: icon
         type: string

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -415,23 +415,30 @@ local function validate_call(name, args, kwargs)
   -- is made here rather than read out of the validator's findings because the
   -- validator reports a nested argument fault under one `arguments` entry,
   -- which cannot tell a missing argument from a malformed one.
-  --- @type table<integer, string>
+  --- @type table<integer, table>
   local missing = {}
   for index, argument in ipairs(entry.arguments or {}) do
     if argument.required == true and str.is_empty(positional[index]) then
-      missing[#missing + 1] = argument.name
+      missing[#missing + 1] = argument
     end
   end
 
   if #missing > 0 then
-    -- The only message for this call. Reporting the schema's wording as well
-    -- would say the same thing twice at two severities, and every other
-    -- finding about a call with no icon is secondary to the missing icon.
-    for _, argument_name in ipairs(missing) do
+    -- The only message about the missing argument: the schema's own `required`
+    -- wording says the same thing, and reporting both would state one fault
+    -- twice at two severities. Attribute warnings above still stand, and every
+    -- other finding about this call is secondary to there being no icon.
+    for _, argument in ipairs(missing) do
+      --- The example comes from the schema so that each shortcode carries its
+      --- own, rather than this message naming one shortcode for all of them.
+      --- @type string
+      local advice = ''
+      local example = type(argument.examples) == 'table' and argument.examples[1] or nil
+      if example ~= nil then
+        advice = string.format(' For example: {{< %s %s >}}.', name, tostring(example))
+      end
       log.log_error(EXTENSION_NAME, string.format(
-        'The "%s" shortcode needs its "%s" argument. ' ..
-        'Write {{< iconify set:icon >}} or {{< iconify set icon >}}.',
-        name, argument_name))
+        'The "%s" shortcode needs its "%s" argument.%s', name, argument.name, advice))
     end
     return
   end

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -603,6 +603,18 @@ local function render_icon(args, kwargs, meta)
     return pandoc.Null()
   end
 
+  -- A call with no positional argument names no icon. Reading `args[1]`
+  -- unguarded raises inside the filter, which ends the whole render with a
+  -- Lua stack trace rather than a message naming the document and the fix.
+  if #args == 0 then
+    log.log_error(
+      EXTENSION_NAME,
+      'The shortcode needs an icon. ' ..
+      'Write {{< iconify set:icon >}} or {{< iconify set icon >}}.'
+    )
+    return pandoc.Null()
+  end
+
   --- @type string
   local icon = str.stringify(args[1])
 

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -409,6 +409,33 @@ local function validate_call(name, args, kwargs)
   for _, message in ipairs(warnings) do
     log.log_warning(EXTENSION_NAME, message)
   end
+
+  -- A required argument that is absent is the one case the rule above does not
+  -- cover: without it there is no icon, so the output does change. The check
+  -- is made here rather than read out of the validator's findings because the
+  -- validator reports a nested argument fault under one `arguments` entry,
+  -- which cannot tell a missing argument from a malformed one.
+  --- @type table<integer, string>
+  local missing = {}
+  for index, argument in ipairs(entry.arguments or {}) do
+    if argument.required == true and str.is_empty(positional[index]) then
+      missing[#missing + 1] = argument.name
+    end
+  end
+
+  if #missing > 0 then
+    -- The only message for this call. Reporting the schema's wording as well
+    -- would say the same thing twice at two severities, and every other
+    -- finding about a call with no icon is secondary to the missing icon.
+    for _, argument_name in ipairs(missing) do
+      log.log_error(EXTENSION_NAME, string.format(
+        'The "%s" shortcode needs its "%s" argument. ' ..
+        'Write {{< iconify set:icon >}} or {{< iconify set icon >}}.',
+        name, argument_name))
+    end
+    return
+  end
+
   for _, message in ipairs(errors) do
     log.log_warning(EXTENSION_NAME, message)
   end
@@ -592,6 +619,16 @@ end
 --- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
 local function render_icon(args, kwargs, meta)
 
+  -- Checked before the format gate below, so a call with no icon is handled
+  -- the same way for every output format rather than only the two that render
+  -- something. An empty first argument counts as no icon, which is what the
+  -- schema's `required` check already decided, so the two agree.
+  -- `validate_call` has reported this to the author; there is nothing to add
+  -- here beyond not reading a first argument that is not there.
+  if #args == 0 or str.is_empty(str.stringify(args[1])) then
+    return pandoc.Null()
+  end
+
   -- HTML (excluding epub which will not host the Web Component) renders the
   -- Web Component; Typst renders a cached SVG. Every other format renders
   -- nothing.
@@ -600,18 +637,6 @@ local function render_icon(args, kwargs, meta)
   --- @type boolean
   local is_typst = quarto.doc.is_format('typst')
   if not is_html and not is_typst then
-    return pandoc.Null()
-  end
-
-  -- A call with no positional argument names no icon. Reading `args[1]`
-  -- unguarded raises inside the filter, which ends the whole render with a
-  -- Lua stack trace rather than a message naming the document and the fix.
-  if #args == 0 then
-    log.log_error(
-      EXTENSION_NAME,
-      'The shortcode needs an icon. ' ..
-      'Write {{< iconify set:icon >}} or {{< iconify set icon >}}.'
-    )
     return pandoc.Null()
   end
 

--- a/tests/schema-defaults.lua
+++ b/tests/schema-defaults.lua
@@ -56,10 +56,16 @@ for _, name in ipairs({ 'size', 'width', 'height', 'flip', 'rotate', 'style',
   end
 end
 
---- The `iconify` shortcode needs an icon to render. The schema says so with
---- `required` on the first argument, and the Lua stops when it is absent, so
---- both halves are checked here: dropping either one would let
---- `{{< iconify >}}` through again.
+--- The `iconify` shortcode needs an icon to render, and the schema says so
+--- with `required` on the first argument.
+---
+--- These checks cover the schema half only: that the flag is declared, and
+--- that the validator counts both an absent and an empty argument as missing.
+--- The Lua that acts on it, the guard in `render_icon` and the report in
+--- `validate_call`, is not exercised here, because loading `iconify.lua`
+--- needs the `quarto` runtime this suite deliberately does without. Removing
+--- that Lua would leave these checks green, so it is covered by rendering a
+--- document instead.
 local extra = 0
 
 local iconify_entry = loaded.shortcodes and loaded.shortcodes.iconify

--- a/tests/schema-defaults.lua
+++ b/tests/schema-defaults.lua
@@ -56,6 +56,44 @@ for _, name in ipairs({ 'size', 'width', 'height', 'flip', 'rotate', 'style',
   end
 end
 
-io.stdout:write(string.format('\n%d checks, %d failed\n', #EXPECTED + 10, failed))
+--- The `iconify` shortcode needs an icon to render. The schema says so with
+--- `required` on the first argument, and the Lua stops when it is absent, so
+--- both halves are checked here: dropping either one would let
+--- `{{< iconify >}}` through again.
+local extra = 0
+
+local iconify_entry = loaded.shortcodes and loaded.shortcodes.iconify
+local first_argument = iconify_entry and iconify_entry.arguments and iconify_entry.arguments[1]
+
+extra = extra + 1
+if first_argument and first_argument.required == true then
+  io.stdout:write('ok   iconify argument 1 is required\n')
+else
+  io.stdout:write('FAIL iconify argument 1 is not declared as required\n')
+  failed = failed + 1
+end
+
+--- A call with no argument, and a call whose argument is empty, must both be
+--- reported. The schema treats an empty string as missing, and the Lua guard
+--- reads the same way, so the two never disagree about what "no icon" means.
+for _, case in ipairs({ { name = 'no argument', args = {} },
+                        { name = 'empty argument', args = { '' } } }) do
+  extra = extra + 1
+  local valid, errors = schema.validate_shortcode('iconify', case.args, {}, iconify_entry)
+  local reported = false
+  for _, message in ipairs(errors or {}) do
+    if message:find('required', 1, true) then
+      reported = true
+    end
+  end
+  if not valid and reported then
+    io.stdout:write('ok   iconify with ' .. case.name .. ' is reported as missing\n')
+  else
+    io.stdout:write('FAIL iconify with ' .. case.name .. ' is not reported as missing\n')
+    failed = failed + 1
+  end
+end
+
+io.stdout:write(string.format('\n%d checks, %d failed\n', #EXPECTED + 10 + extra, failed))
 io.stdout:flush()
 os.exit(failed == 0 and 0 or 1, true)


### PR DESCRIPTION
The `iconify` shortcode read its first positional argument without a guard, so `{{< iconify >}}` raised inside the filter and ended the whole render with a Lua stack trace. Nothing in the trace named the document or the fix.

The shortcode now reports the error and renders nothing, and the render continues.

`_schema.yml` declared neither positional argument as required, so the declared contract permitted a call the implementation could not handle. `set-or-icon` is now marked required, which also makes the existing shortcode validation report the missing argument in its own words.

The `quarto` shortcode always supplies its own icon argument, so it is unaffected.

Verified with `tests/schema-defaults.lua` (15 checks, 0 failed) and by rendering a document containing a bare `{{< iconify >}}`, which now completes and reports both the schema warning and the error.