### PR TITLE
feat: declare the vendored modules in a manifest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# The called workflow declares an `issue` job asking for `issues: write`, and a
-# called job cannot request more than the caller grants. That is validated when
-# the run starts, before the job's own `if` is reached, so the permission is
-# needed even though `issue-on-failure` is not set and the job never runs.
 permissions:
   contents: read
-  issues: write
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+# The extension test framework renders this repository's test documents and
+# checks the dependency manifest. A pull request runs it unless it is still a
+# draft, and the default activity types fire nothing when a pull request leaves
+# draft, so `ready_for_review` is what runs it once the draft is lifted.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # `github.event.pull_request` is null on a push, so this reads true there.
+    if: ${{ github.event.pull_request.draft != true }}
+    uses: mcanouil/quarto-extension-test/.github/workflows/extension-test.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The called workflow declares an `issue` job asking for `issues: write`, and a
+# called job cannot request more than the caller grants. That is validated when
+# the run starts, before the job's own `if` is reached, so the permission is
+# needed even though `issue-on-failure` is not set and the job never runs.
 permissions:
   contents: read
+  issues: write
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ index.html
 /.quarto
 /.quarto/
 **/*.quarto_ipynb
+
+# Written by the extension test framework's runner. It renders the repository's
+# own documents, so `example.qmd` leaves its Typst output at the root under the
+# name that document's `output-file` gives it. `tests/` keeps its own
+# `.gitignore` for the project directory Quarto creates there.
+/tests/_results/
+/tests/_output/
+/iconify-typst.pdf

--- a/.quartoignore
+++ b/.quartoignore
@@ -9,3 +9,6 @@ docs
 
 # The repository's own citation metadata, not the new project's.
 CITATION.cff
+
+# The test framework and the cases it runs against this extension.
+tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 - fix: Report an error when the `iconify` shortcode names no icon. Such a call raised a Lua error that stopped the whole render, and `_schema.yml` now marks the first argument as required. (#87)
 
+### Refactoring
+
+- build: Declare the vendored Lua modules in `_extensions/iconify/_dependencies.yml` and move them to `_extensions/iconify/_vendor/`, so each one names the release it came from and can be checked against it.
+- build: Update the vendored schema validator to the one Quarto Wizard 3.4.0 publishes.
+
 ## 4.1.2 (2026-08-08)
 
 ### Bug Fixes

--- a/_extensions/iconify/_dependencies.yml
+++ b/_extensions/iconify/_dependencies.yml
@@ -1,0 +1,26 @@
+schema: 1
+sources:
+  quarto-lua-modules:
+    origin: "https://github.com/mcanouil/quarto-lua-modules"
+    fetch: "{origin}/releases/download/{version}/{file}"
+    version: "2.0.0"
+    licence: MIT
+    files:
+      logging.lua:
+        sha256: "a69a69ce7cf41b02914889074eb7445cff72003e6dd8b55b6f47d32d09848ccd"
+        runtime: any
+      metadata.lua:
+        sha256: "3f82a6208c337ae9a2e4a0a6f294f894cc506e05aedfb1c13167e55b52b8c457"
+        runtime: any
+      string.lua:
+        sha256: "32b2c16f50ecf7e752441ed80bd7fbcee11af83c4ed1e9242cc745d200bc73e0"
+        runtime: any
+  quarto-wizard:
+    origin: "https://github.com/mcanouil/quarto-wizard"
+    fetch: "https://raw.githubusercontent.com/mcanouil/quarto-wizard/{version}/packages/schema/src/validation/{file}"
+    version: "3.4.0"
+    licence: MIT
+    files:
+      schema.lua:
+        sha256: "30b830304ddeb410e507edf176ce4e056cdc242d51161f5f8a8d65a2e01ecd5a"
+        runtime: any

--- a/_extensions/iconify/_modules/typst.lua
+++ b/_extensions/iconify/_modules/typst.lua
@@ -15,17 +15,8 @@
 
 local M = {}
 
---- Load a sibling module from the same directory as this file.
---- @param filename string The sibling module filename (e.g., 'string.lua')
---- @return table The loaded module
-local function load_sibling(filename)
-  local source = debug.getinfo(1, 'S').source:sub(2)
-  local dir = source:match('(.*[/\\])') or ''
-  return require((dir .. filename):gsub('%.lua$', ''))
-end
-
-local str = load_sibling('string.lua')
-local log = load_sibling('logging.lua')
+local str = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/string.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/logging.lua'):gsub('%.lua$', ''))
 
 --- Extension name constant
 local EXTENSION_NAME = 'iconify'

--- a/_extensions/iconify/_vendor/quarto-lua-modules/LICENSE
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_extensions/iconify/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 1.0.0
+--- @version 2.0.0
 
 local M = {}
 

--- a/_extensions/iconify/_vendor/quarto-lua-modules/metadata.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/metadata.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 1.0.0
+--- @version 2.0.0
 
 local M = {}
 

--- a/_extensions/iconify/_vendor/quarto-lua-modules/string.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/string.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 1.1.0
+--- @version 2.0.0
 
 local M = {}
 

--- a/_extensions/iconify/_vendor/quarto-wizard/LICENSE
+++ b/_extensions/iconify/_vendor/quarto-wizard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_extensions/iconify/_vendor/quarto-wizard/schema.lua
+++ b/_extensions/iconify/_vendor/quarto-wizard/schema.lua
@@ -153,7 +153,7 @@ local function _lookup(map, key)
   if underscored ~= key and map[underscored] ~= nil then
     return map[underscored], underscored
   end
-  local hyphenated = (key:gsub('_', '%-'))
+  local hyphenated = (key:gsub('_', '-'))
   if hyphenated ~= key and map[hyphenated] ~= nil then
     return map[hyphenated], hyphenated
   end
@@ -167,6 +167,9 @@ end
 local function _format_value(value)
   local kind = type(value)
   if kind == 'string' then
+    if value == '' then
+      return '""'
+    end
     return value
   elseif kind == 'number' or kind == 'boolean' then
     return tostring(value)
@@ -361,6 +364,16 @@ local ESCAPE_INSIDE = {
   d = '%d', D = '%D', w = '%w_', s = '%s', S = '%S',
 }
 
+--- Escapes with a real Lua equivalent. Anything else alphanumeric is refused,
+--- because compiling it to the bare letter would accept the wrong values.
+local CONTROL_ESCAPES = {
+  n = '\n',
+  t = '\t',
+  r = '\r',
+  f = '\f',
+  v = '\v',
+}
+
 --- Characters Lua treats as magic outside a character class.
 local LUA_MAGIC = '^$()%.[]*+-?'
 
@@ -386,6 +399,7 @@ local function _compile_pattern(regex)
   local length = #regex
   local anchor_start = false
   local anchor_end = false
+  local has_top_level_alternation = false
   local parse_alternation
 
   --- Combine a set of prefixes with a set of continuations.
@@ -431,12 +445,14 @@ local function _compile_pattern(regex)
         local mapped = ESCAPE_INSIDE[next_char]
         if mapped then
           out[#out + 1] = mapped
-        elseif next_char:match('%d') then
+        elseif next_char:match('[1-9]') then
           return nil, 'unsupported backreference "\\' .. next_char .. '"'
         elseif next_char == '%' then
           out[#out + 1] = '%%'
+        elseif CONTROL_ESCAPES[next_char] then
+          out[#out + 1] = CONTROL_ESCAPES[next_char]
         elseif next_char:match('%w') then
-          out[#out + 1] = next_char
+          return nil, 'unsupported escape "\\' .. next_char .. '"'
         else
           out[#out + 1] = '%' .. next_char
         end
@@ -522,8 +538,10 @@ local function _compile_pattern(regex)
       local atom
       if mapped then
         atom = mapped
+      elseif CONTROL_ESCAPES[next_char] then
+        atom = CONTROL_ESCAPES[next_char]
       elseif next_char:match('%w') then
-        atom = next_char
+        return nil, 'unsupported escape "\\' .. next_char .. '"'
       else
         atom = _escape_literal(next_char)
       end
@@ -603,7 +621,9 @@ local function _compile_pattern(regex)
 
   parse_alternation = function(depth)
     local all = {}
+    local iterations = 0
     while true do
+      iterations = iterations + 1
       local branches, reason = parse_sequence(depth)
       if not branches then
         return nil, reason
@@ -620,6 +640,9 @@ local function _compile_pattern(regex)
         break
       end
     end
+    if depth == 0 and iterations > 1 then
+      has_top_level_alternation = true
+    end
     return all
   end
 
@@ -629,6 +652,12 @@ local function _compile_pattern(regex)
   end
   if position <= length then
     return nil, 'unbalanced ")" in pattern'
+  end
+
+  -- The anchors are collected for the expression as a whole, so applying them
+  -- to multiple top-level branches would anchor branches the author did not anchor.
+  if has_top_level_alternation and (anchor_start or anchor_end) then
+    return nil, 'unsupported anchor in a top-level alternation'
   end
 
   local prefix = anchor_start and '^' or ''
@@ -667,28 +696,47 @@ end
 --- @param value any Pandoc metadata value
 --- @return any Native Lua value
 local function _convert_pandoc_value(value)
+  local kind = _env.pandoc_type(value)
+
+  -- A bare key, `null` and `~` all arrive as an empty Pandoc `string`, which
+  -- is how Pandoc collapses YAML null. An explicit `""` arrives as an empty
+  -- `Inlines` instead, so the two are told apart before either is unwrapped.
+  if kind == 'string' and value == '' then
+    return nil
+  end
+
   if type(value) ~= 'table' then
     return value
   end
-
-  local kind = _env.pandoc_type(value)
 
   if kind == 'Inlines' or kind == 'Blocks' or kind == 'Inline' or kind == 'Block' then
     return _env.stringify(value)
   end
 
   if kind == 'List' then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
     local result = {}
     for index = 1, #value do
-      result[index] = _convert_pandoc_value(value[index])
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
     end
     return result
   end
 
   if _is_array(value) and #value > 0 then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
     local result = {}
     for index = 1, #value do
-      result[index] = _convert_pandoc_value(value[index])
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
     end
     return result
   end
@@ -1123,6 +1171,7 @@ local function _read_block_scalar(lines, start, parent_indent, style)
 end
 
 local _parse_block
+local _parse_sequence
 
 --- The order in which each parsed mapping declared its keys.
 --- Lua tables have no key order, but a schema is authored in a meaningful one,
@@ -1200,6 +1249,23 @@ local function _parse_map(lines, start, indent, depth)
           if err then
             return nil, next_index, err
           end
+
+          -- A block sequence may sit at the column of its own key, which
+          -- `_parse_block` declines because its guard wants a deeper line.
+          -- Nothing was consumed in that case, so read the sequence here.
+          if value == nil and next_index == index then
+            local peek = _skip_insignificant(lines, index)
+            if peek <= #lines and lines[peek].indent == indent then
+              local ahead = _content(lines[peek])
+              if ahead == '-' or ahead:sub(1, 2) == '- ' then
+                value, next_index, err = _parse_sequence(lines, peek, indent, depth + 1)
+                if err then
+                  return nil, next_index, err
+                end
+              end
+            end
+          end
+
           map[key] = value
           index = next_index
         elseif rest:sub(1, 1) == '[' or rest:sub(1, 1) == '{' then
@@ -1232,7 +1298,7 @@ end
 --- @return table|nil sequence
 --- @return number next_index
 --- @return string|nil err
-local function _parse_sequence(lines, start, indent, depth)
+_parse_sequence = function(lines, start, indent, depth)
   local sequence = {}
   local index = start
 
@@ -1664,12 +1730,18 @@ local function _check_array(value, spec, path, context)
   if spec.uniqueItems == true then
     local seen = {}
     for index = 1, length do
-      -- Key on the type as well as the rendering, so the number 1 and the
-      -- string "1" are not read as the same item.
-      local key = type(value[index]) .. '\0' .. _format_value(value[index])
+      local element = value[index]
+      local rendered = _format_value(element)
+      -- The key carries the type so 1 and "1" are different items. A string
+      -- keys on its own text rather than on the rendering, because
+      -- `_format_value` renders an empty string as `""`, which would make it
+      -- collide with the two-character string `""`. The message carries only
+      -- the rendering, because the key is not the author's text.
+      local raw = type(element) == 'string' and element or rendered
+      local key = type(element) .. '\0' .. raw
       if seen[key] then
         _report(context, 'error', path, 'uniqueItems', string.format(
-          'must not repeat items, but %s appears more than once.', key
+          'must not repeat items, but %s appears more than once.', rendered
         ))
         break
       end
@@ -1686,7 +1758,7 @@ local function _check_items(value, spec, path, context)
   for index = 1, #value do
     local element = _coerce(value[index], spec.items.type)
     value[index] = element
-    if element ~= nil and element ~= '' then
+    if element ~= nil then
       _validate_value(element, spec.items, string.format('%s[%d]', path, index), context)
     end
   end
@@ -1715,22 +1787,10 @@ local function _check_object(value, spec, path, context)
     end
   end
 
-  if type(spec.dependentRequired) == 'table' then
-    for key, dependents in pairs(spec.dependentRequired) do
-      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
-        for _, dependent in ipairs(dependents) do
-          if _lookup(value, dependent) == nil then
-            _report(context, 'error', path, 'dependentRequired', string.format(
-              'requires "%s" when "%s" is present.', dependent, key
-            ))
-          end
-        end
-      end
-    end
-  end
+  local defaulted = {}
 
   if type(spec.properties) == 'table' then
-    local sub = _validate_map(value, spec.properties, path, context, {
+    local sub, filled = _validate_map(value, spec.properties, path, context, {
       unknown = spec.additionalProperties == false and 'error' or 'ignore',
       additional = type(spec.additionalProperties) == 'table' and spec.additionalProperties or nil,
     })
@@ -1750,12 +1810,34 @@ local function _check_object(value, spec, path, context)
     for key, member in pairs(sub) do
       value[key] = member
     end
+    defaulted = filled
   elseif type(spec.additionalProperties) == 'table' then
     for key, member in pairs(value) do
       local coerced = _coerce(member, spec.additionalProperties.type)
       value[key] = coerced
-      if coerced ~= nil and coerced ~= '' then
+      if coerced ~= nil then
         _validate_value(coerced, spec.additionalProperties, path .. '.' .. tostring(key), context)
+      end
+    end
+  end
+
+  -- Runs after the properties block, which writes the resolved members back
+  -- into `value`. Before that, a dependent supplied under an alias is not yet
+  -- there to be found. A `default` is an annotation and does not change the
+  -- instance, so a key that only holds one neither triggers a requirement nor
+  -- satisfies it.
+  if type(spec.dependentRequired) == 'table' then
+    for key, dependents in pairs(spec.dependentRequired) do
+      local trigger, trigger_key = _lookup(value, key)
+      if trigger ~= nil and not defaulted[trigger_key] and type(dependents) == 'table' then
+        for _, dependent in ipairs(dependents) do
+          local supplied, dependent_key = _lookup(value, dependent)
+          if supplied == nil or defaulted[dependent_key] then
+            _report(context, 'error', path, 'dependentRequired', string.format(
+              'requires "%s" when "%s" is present.', dependent, key
+            ))
+          end
+        end
       end
     end
   end
@@ -1863,6 +1945,40 @@ local function _apply_deprecation(field, spec, value, merged)
   return message, cleared
 end
 
+--- Record that a descriptor accepts a spelling, and report a contested one.
+---
+--- Two descriptors can name the same spelling, when one declares as an alias
+--- what another declares as its own name, or when two of them declare the same
+--- alias. `pairs` yields descriptors in no particular order, so which field a
+--- contested spelling resolves to is not decidable from the schema. It is
+--- reported rather than resolved in silence, because the schema is what is
+--- wrong and only its author can settle it.
+---
+--- @param sources table Map of spelling to declared name
+--- @param spelling string The spelling being declared
+--- @param field string The declared name that accepts it
+--- @param base_path string|nil Path prefix for findings
+--- @param context table Validation context
+local function _declare_spelling(sources, spelling, field, base_path, context)
+  -- The owner is read through `_lookup`, like every other name comparison in
+  -- this module, so a contest between the hyphen and the underscore spelling
+  -- of one name is found as well. Those sit under different keys but reach the
+  -- same document key at merge time, so they contest just as directly.
+  local owner = _lookup(sources, spelling)
+  if owner ~= nil and owner ~= field then
+    _report(context, 'warning', base_path and (base_path .. '.' .. spelling) or spelling,
+      'aliases', string.format(
+        'is declared by both "%s" and "%s"; which one accepts it is not defined.',
+        owner, field))
+  end
+  -- Stored under the literal spelling either way. The map is also the set of
+  -- keys a descriptor claimed, and a contested spelling is still claimed: the
+  -- schema is ambiguous, which the warning says, and treating the key as
+  -- undeclared on top of that would report it as unknown as well.
+  sources[spelling] = sources[spelling] or field
+end
+
+
 --- Validate a map of values against a map of field descriptors.
 --- @param values table Values to validate
 --- @param descriptors table Field descriptor map
@@ -1870,6 +1986,13 @@ end
 --- @param context table Validation context
 --- @param options table|nil {unknown = 'warn'|'error'|'ignore', additional = descriptor}
 --- @return table merged Values with aliases, coercion and defaults applied
+--- @return table defaulted Set of field names whose value came from `default`
+--- @return table sources Map of every spelling the schema accepts to the
+---   declared name it resolves to. A reader that has to answer a question
+---   about a name the caller wrote asks this rather than walking the
+---   descriptors again, because the merge has already decided the answer.
+---   It doubles as the set of keys a descriptor claimed, which is what the
+---   unknown key pass below reads.
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1879,7 +2002,8 @@ _validate_map = function(values, descriptors, base_path, context, options)
     merged[key] = value
   end
 
-  local claimed = {}
+  local defaulted = {}
+  local sources = {}
   local fields = {}
 
   -- Three passes, because `pairs` yields descriptors in no particular order.
@@ -1892,34 +2016,50 @@ _validate_map = function(values, descriptors, base_path, context, options)
       spec = spec,
       path = base_path and (base_path .. '.' .. field) or field,
     }
-    claimed[field] = true
+    -- Two writes with different weight. Declaring a spelling fills an empty
+    -- slot only, while claiming the value under one overwrites whatever was
+    -- there. The value lands under whichever descriptor claimed it, so the
+    -- claim is what the map has to follow: a declaration that outranked it
+    -- would send a reader to a field the merge has already emptied.
+    _declare_spelling(sources, field, field, base_path, context)
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
     -- never carries the same value twice, once coerced and once raw.
-    if type(spec.aliases) == 'table' then
-      for _, alias in ipairs(spec.aliases) do
-        claimed[alias] = true
-        if merged[field] == nil then
-          local aliased, alias_key = _lookup(merged, alias)
-          if aliased ~= nil then
-            merged[field] = aliased
-            claimed[alias_key] = true
-            if alias_key ~= field then
-              merged[alias_key] = nil
-            end
-          end
-        end
+    -- The declared name is read first, so it wins over any alias.
+    local supplied_key
+    local found, found_key = _lookup(merged, field)
+    if found ~= nil then
+      merged[field] = found
+      sources[found_key] = field
+      supplied_key = found_key
+      if found_key ~= field then
+        merged[found_key] = nil
       end
     end
 
-    if merged[field] == nil then
-      local found, found_key = _lookup(merged, field)
-      if found ~= nil then
-        merged[field] = found
-        claimed[found_key] = true
-        if found_key ~= field then
-          merged[found_key] = nil
+    if type(spec.aliases) == 'table' then
+      for _, alias in ipairs(spec.aliases) do
+        _declare_spelling(sources, alias, field, base_path, context)
+        local aliased, alias_key = _lookup(merged, alias)
+        if aliased ~= nil then
+          sources[alias_key] = field
+          if merged[field] == nil then
+            merged[field] = aliased
+            supplied_key = alias_key
+          elseif alias_key ~= field then
+            -- Two spellings were supplied. The first one read wins, and the
+            -- other is reported rather than left behind unvalidated. Both
+            -- names come from the document, never from the schema.
+            _report(context, 'warning',
+              base_path and (base_path .. '.' .. field) or field,
+              'aliases',
+              string.format('was given as both "%s" and "%s"; "%s" was used.',
+                supplied_key, alias_key, supplied_key))
+          end
+          if alias_key ~= field then
+            merged[alias_key] = nil
+          end
         end
       end
     end
@@ -1927,7 +2067,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   for _, entry in ipairs(fields) do
     local value = merged[entry.name]
-    if entry.spec.deprecated and value ~= nil and value ~= '' then
+    if entry.spec.deprecated and value ~= nil then
       local message, cleared = _apply_deprecation(entry.name, entry.spec, value, merged)
       _report(context, 'warning', entry.path, 'deprecated', message)
       entry.cleared = cleared
@@ -1944,29 +2084,30 @@ _validate_map = function(values, descriptors, base_path, context, options)
       value = _coerce(merged[field], spec.type)
       merged[field] = value
 
-      if (value == nil or value == '') and spec.default ~= nil then
+      if value == nil and spec.default ~= nil then
         value = spec.default
         merged[field] = value
+        defaulted[field] = true
       end
     end
 
-    local is_empty = value == nil or value == ''
-
-    if spec.required == true and is_empty then
+    -- An empty string is a value the author wrote. Only a missing key is
+    -- absent, so `minLength`, `const` and `enum` can be tested against ''.
+    if spec.required == true and value == nil then
       _report(context, 'error', path, 'required', 'is required but was not provided.')
-    elseif not is_empty then
+    elseif value ~= nil then
       _validate_value(value, spec, path, context)
     end
   end
 
   if unknown_policy ~= 'ignore' or options.additional then
     for key, value in pairs(values) do
-      if not claimed[key] then
+      if sources[key] == nil then
         local path = base_path and (base_path .. '.' .. tostring(key)) or tostring(key)
         if options.additional then
           local coerced = _coerce(value, options.additional.type)
           merged[key] = coerced
-          if coerced ~= nil and coerced ~= '' then
+          if coerced ~= nil then
             _validate_value(coerced, options.additional, path, context)
           end
         elseif unknown_policy == 'error' then
@@ -1978,7 +2119,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     end
   end
 
-  return merged
+  return merged, defaulted, sources
 end
 
 --- Start a validation run.
@@ -2105,15 +2246,14 @@ function M.validate_arguments(args, argument_specs, options)
     local path = string.format('argument %d ("%s")', index, name)
 
     local value = _coerce(args[index], spec.type)
-    if (value == nil or value == '') and spec.default ~= nil then
+    if value == nil and spec.default ~= nil then
       value = spec.default
     end
     merged[name] = value
 
-    local is_empty = value == nil or value == ''
-    if spec.required == true and is_empty then
+    if spec.required == true and value == nil then
       _report(context, 'error', path, 'required', 'is required but was not provided.')
-    elseif not is_empty then
+    elseif value ~= nil then
       _validate_value(value, spec, path, context)
     end
   end
@@ -2160,15 +2300,50 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     end
   end
 
-  if type(entry.attributes) == 'table' then
-    merged.attributes = _validate_map(kwargs or {}, entry.attributes, name, context, {
+  local declared = type(entry.attributes) == 'table'
+  local spellings
+  if declared then
+    local attributes, _, resolved = _validate_map(kwargs or {}, entry.attributes, name, context, {
       unknown = options.unknown or 'warn',
     })
+    merged.attributes = attributes
+    spellings = resolved
   end
 
   if type(entry.required) == 'table' then
+    -- `merged.attributes` is filled only when the entry declares `attributes`,
+    -- and it is authoritative when it is: it keeps every unclaimed key and it
+    -- drops a key that a deprecation cleared. The vocabulary allows `required`
+    -- on its own, so fall back to what the caller supplied only when the
+    -- entry declares no `attributes`. A name that names an alias is not
+    -- missing either: `_validate_map` moves its value to the field that
+    -- declares the alias and clears the alias spelling, the same way it
+    -- clears a deprecated key, so look for the value under that field. The
+    -- merge reports which declared name each spelling resolves to, so that
+    -- is one lookup rather than a second walk over the descriptors. It goes
+    -- through `_lookup`, the same as every other name comparison in this
+    -- module, so a hyphen in one spelling and an underscore in the other
+    -- still match.
+    --
+    -- This asks what the shortcode receives, not what the author wrote, so
+    -- a `default` present in `merged.attributes` satisfies a name here.
+    -- That is the opposite of `dependentRequired` above, which asks what
+    -- the author wrote and treats a default as an annotation nobody
+    -- supplied. Neither reading is a bug: they answer different questions
+    -- about the same instance.
+    local function _required_satisfied(required)
+      local field = (spellings and _lookup(spellings, required)) or required
+      if _lookup(merged.attributes, field) ~= nil then
+        return true
+      end
+      if not declared then
+        return _lookup(kwargs or {}, required) ~= nil
+      end
+      return false
+    end
+
     for _, required in ipairs(entry.required) do
-      if _lookup(merged.attributes, required) == nil then
+      if not _required_satisfied(required) then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/_extensions/iconify/iconify-filter.lua
+++ b/_extensions/iconify/iconify-filter.lua
@@ -14,8 +14,8 @@
 local EXTENSION_NAME = "iconify"
 
 --- Load modules
-local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua$', ''))
-local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local str = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/string.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/logging.lua'):gsub('%.lua$', ''))
 
 --- Tracker so the preload payload is only injected once per document, even
 --- when the filter runs multiple passes.

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -7,11 +7,11 @@
 local EXTENSION_NAME = "iconify"
 
 --- Load modules
-local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua$', ''))
-local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
-local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
+local str = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/string.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/logging.lua'):gsub('%.lua$', ''))
+local meta_mod = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/metadata.lua'):gsub('%.lua$', ''))
 local typst = require(quarto.utils.resolve_path('_modules/typst.lua'):gsub('%.lua$', ''))
-local schema = require(quarto.utils.resolve_path('_modules/schema.lua'):gsub('%.lua$', ''))
+local schema = require(quarto.utils.resolve_path('_vendor/quarto-wizard/schema.lua'):gsub('%.lua$', ''))
 
 --- The parsed `_schema.yml`, loaded once and reused by every shortcode call.
 --- Nil means the file could not be read, in which case calls are not checked

--- a/docs/_filters/schema-tables.lua
+++ b/docs/_filters/schema-tables.lua
@@ -33,7 +33,7 @@ local schema_path = root_dir .. '_extensions/iconify/_schema.yml'
 --- Loaded with `dofile` rather than `require`, because `require` reads a
 --- module name and turns every `.` in it into a directory separator, which
 --- destroys the `../..` this relative path needs.
-local ok, schema = pcall(dofile, root_dir .. '_extensions/iconify/_modules/schema.lua')
+local ok, schema = pcall(dofile, root_dir .. '_extensions/iconify/_vendor/quarto-wizard/schema.lua')
 if not ok or type(schema) ~= 'table' then
   io.stderr:write('[schema-tables] could not load the schema module: ' .. tostring(schema) .. '\n')
   return {}

--- a/docs/_scripts/sync-extension.sh
+++ b/docs/_scripts/sync-extension.sh
@@ -3,9 +3,9 @@
 # Documentation Extension Sync
 # Mirrors the repository's own extension into the documentation project.
 #
-# @license %%license%%
-# @copyright %%year%% %%author%%
-# @author %%author%%
+# @license MIT License
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
 #
 # The website demonstrates the extension it documents, so the extension has to
 # be resolvable from docs/. Quarto builds its extension registry while reading

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/tests/_extensions/mcanouil/extension-test/LICENSE
+++ b/tests/_extensions/mcanouil/extension-test/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/_extensions/mcanouil/extension-test/_dependencies.yml
+++ b/tests/_extensions/mcanouil/extension-test/_dependencies.yml
@@ -1,0 +1,11 @@
+schema: 1
+sources:
+  quarto-wizard:
+    origin: https://github.com/mcanouil/quarto-wizard
+    fetch: "https://raw.githubusercontent.com/mcanouil/quarto-wizard/{version}/packages/schema/src/validation/{file}"
+    version: "3.4.0"
+    licence: MIT
+    files:
+      schema.lua:
+        sha256: 30b830304ddeb410e507edf176ce4e056cdc242d51161f5f8a8d65a2e01ecd5a
+        runtime: any

--- a/tests/_extensions/mcanouil/extension-test/_extension.yml
+++ b/tests/_extensions/mcanouil/extension-test/_extension.yml
@@ -1,0 +1,9 @@
+title: Extension Test
+author: Mickaël Canouil
+version: 0.0.0
+quarto-required: ">=1.6"
+contributes:
+  project:
+    project:
+      type: default
+      output-dir: _output

--- a/tests/_extensions/mcanouil/extension-test/_modules/conformance.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/conformance.lua
@@ -1,0 +1,804 @@
+--- Extension Test - Layer A, conformance.
+---
+--- Generalises the reference conformance sweep from "walk directories looking
+--- for `_schema.yml`" into "check the extensions of one repository". Two
+--- defects in that reference are fixed here. It iterated with `pairs()`, so
+--- its findings reordered between runs and could not be diffed; every
+--- iteration below goes through `schema.key_order` or a sorted key list.
+--- And it exited non-zero both when it found problems and when it found no
+--- schemas at all, conflating a failure with a skip.
+
+local util = require('util')
+local schema = require('schema')
+
+local M = {}
+
+--- Schema file names, in Quarto's own resolution order. A JSON schema wins
+--- over YAML in the same directory. The reference parser reads pretty-printed
+--- JSON correctly, so all three take the same path.
+local SCHEMA_FILENAMES = { '_schema.json', '_schema.yml', '_schema.yaml' }
+
+--- Contribution keys observed across the published extension corpus.
+--- Unrecognised keys warn rather than fail: the full set Quarto accepts has
+--- not been confirmed against the CLI source.
+local KNOWN_CONTRIBUTIONS = {
+  'shortcodes', 'filters', 'formats', 'project', 'metadata',
+  'revealjs-plugins', 'engines', 'brand',
+}
+
+--- Types the v2 vocabulary allows.
+local V2_TYPES = {
+  string = true, number = true, integer = true, boolean = true,
+  array = true, object = true, ['null'] = true, content = true,
+}
+
+--- Keywords that only ever appeared in the v1 vocabulary.
+local V1_ONLY = { 'min', 'max', 'enum-case-insensitive', 'element-attributes', 'pattern-exact' }
+
+--- Keys a shortcode entry may carry; the meta-schema forbids the rest.
+local SHORTCODE_KEYS = { description = true, arguments = true, attributes = true, required = true }
+
+--- Pandoc elements an attribute group may name.
+local ELEMENTS = { div = true, span = true, code = true, codeblock = true, header = true }
+
+--- Find the extensions a repository ships.
+---
+--- Only `<root>/_extensions/<name>/` counts. A vendored copy under `docs/` or
+--- a staged copy under `tests/` documents or exercises an extension rather
+--- than being one, and including either would report another author's
+--- problems as this repository's.
+--- @param root string repository root
+--- @return table[] list of {name, dir}
+function M.discover(root)
+  local base = util.join(root, '_extensions')
+  local found = {}
+  for _, name in ipairs(util.list_dir(base)) do
+    local dir = util.join(base, name)
+    if util.is_dir(dir) and util.exists(util.join(dir, '_extension.yml')) then
+      found[#found + 1] = { name = name, dir = dir }
+    end
+  end
+  return found
+end
+
+--- Resolve an extension's schema file, in Quarto's order.
+--- @param dir string
+--- @return string|nil path
+local function find_schema(dir)
+  for _, name in ipairs(SCHEMA_FILENAMES) do
+    local path = util.join(dir, name)
+    if util.exists(path) then
+      return path
+    end
+  end
+  return nil
+end
+
+--- Classify a schema's declared vocabulary.
+--- @param path string
+--- @return string version one of v2, v1, unknown, missing
+--- @return string|nil detail
+local function schema_vocabulary(path)
+  local text = util.read_file(path) or ''
+  local declared = text:match('%$schema%s*:%s*["\']?([^"\'%s]+)')
+  if declared then
+    if declared == schema.SCHEMA_VERSION then
+      return 'v2', declared
+    end
+    if declared:find('/v1/', 1, true) then
+      return 'v1', declared
+    end
+    return 'unknown', declared
+  end
+  for _, keyword in ipairs(V1_ONLY) do
+    if text:match('%f[%w-]' .. keyword:gsub('%-', '%%-') .. '%s*:') then
+      return 'v1', 'inferred from `' .. keyword .. '`'
+    end
+  end
+  return 'missing', nil
+end
+
+--- Build a case table.
+local function case(id, status, message, stage, reason)
+  local entry = { id = id, layer = 'conformance', status = status }
+  if status ~= 'pass' then
+    entry.failure = { stage = stage or 'conformance', reason = reason or 'invalid', message = message }
+  end
+  return entry
+end
+
+--- Build an advisory: a passing case carrying a warning.
+---
+--- An advisory reports a real problem without failing the run. It is the
+--- right shape for a finding the extension's author should act on but which
+--- does not make the extension wrong, and for a finding whose rule the
+--- framework is not yet confident enough to enforce.
+local function advisory(id, message)
+  return {
+    id = id,
+    layer = 'conformance',
+    status = 'pass',
+    diagnostics = { warnings = { message }, errors = {} },
+  }
+end
+
+--- Check one extension's `_extension.yml`.
+--- @param ext table {name, dir}
+--- @param manifest_schema table descriptors from manifest-schema.yml
+--- @param emit function(case)
+local function check_manifest(ext, manifest_schema, emit)
+  local path = util.join(ext.dir, '_extension.yml')
+  local id = 'conformance/manifest/' .. ext.name
+
+  local text, read_err = util.read_file(path)
+  if not text then
+    emit(case(id, 'fail', read_err, 'discover', 'manifest-unreadable'))
+    return nil
+  end
+
+  local parsed = schema._parse_yaml_text(text)
+  if type(parsed) ~= 'table' then
+    emit(case(id, 'fail', 'the manifest is not a YAML mapping', 'discover', 'manifest-unparseable'))
+    return nil
+  end
+
+  local valid, errors, warnings = schema.validate(parsed, manifest_schema, { unknown = 'ignore' })
+  if not valid then
+    emit(case(id, 'fail', table.concat(util.sorted_messages(errors), '; '), 'conformance', 'manifest-invalid'))
+  else
+    emit(case(id, 'pass'))
+  end
+  for index, warning in ipairs(util.sorted_messages(warnings)) do
+    emit(advisory(string.format('%s/warning/%d', id, index), warning))
+  end
+
+  local contributes = parsed.contributes
+  if type(contributes) == 'table' then
+    for _, key in ipairs(util.sorted_keys(contributes)) do
+      if not util.contains(KNOWN_CONTRIBUTIONS, key) then
+        -- Advisory, not a failure: the full set of contribution keys Quarto
+        -- accepts has not been confirmed against the CLI source, so an
+        -- unrecognised key is more likely a gap here than a defect there.
+        emit(advisory('conformance/contributes/' .. ext.name .. '/' .. key,
+          string.format('unrecognised contribution `%s`', key)))
+      end
+    end
+    M.check_contributed_paths(ext, contributes, emit)
+  end
+
+  return parsed
+end
+
+--- Every file a `contributes` shortcode or filter names must exist.
+---
+--- A rename that a render would only surface for one format shows up here for
+--- every extension, before anything is rendered at all. Limited to the two
+--- kinds that name a Lua file directly: `formats`, `revealjs-plugins` and
+--- `brand` reference their resources in other ways and are not checked.
+--- @param ext table
+--- @param contributes table
+--- @param emit function
+function M.check_contributed_paths(ext, contributes, emit)
+  local function check_one(kind, value)
+    local path
+    if type(value) == 'string' then
+      path = value
+    elseif type(value) == 'table' and type(value.path) == 'string' then
+      -- Quarto also accepts `{at: pre|post, path: <file>}` for filters.
+      path = value.path
+    else
+      return
+    end
+    if path:match('^%a+://') then
+      return
+    end
+    local id = string.format('conformance/path/%s/%s/%s', ext.name, kind, path)
+    if util.exists(util.join(ext.dir, path)) then
+      emit(case(id, 'pass'))
+    else
+      emit(case(id, 'fail', string.format('`contributes.%s` names `%s`, which does not exist', kind, path),
+        'conformance', 'missing-contributed-file'))
+    end
+  end
+
+  for _, kind in ipairs({ 'shortcodes', 'filters' }) do
+    local entries = contributes[kind]
+    if type(entries) == 'table' then
+      for _, value in ipairs(entries) do
+        check_one(kind, value)
+      end
+    end
+  end
+end
+
+--- Check one extension's `_schema.yml`.
+--- @param ext table
+--- @param severity string
+--- @param emit function
+--- @return table|nil loaded schema, when it is v2 and usable by the smoke layer
+local function check_schema(ext, severity, emit)
+  local id = 'conformance/schema/' .. ext.name
+  local path = find_schema(ext.dir)
+
+  if not path then
+    emit(case(id, 'skip', 'the extension ships no `_schema.yml`', 'conformance', 'schema-absent'))
+    return nil
+  end
+
+  local vocabulary, detail = schema_vocabulary(path)
+  if vocabulary == 'v1' then
+    emit(case(id, 'skip', string.format(
+      'the schema uses the v1 vocabulary (%s); the runner validates v2 only. ' ..
+      'Rename `min` to `minimum`, `max` to `maximum`, `enum-case-insensitive` to ' ..
+      '`enumCaseInsensitive`, `element-attributes` to `attributes`, and replace ' ..
+      '`pattern-exact` with an anchored `pattern`, then declare `$schema: %s`.',
+      detail, schema.SCHEMA_VERSION), 'conformance', 'schema-v1-not-supported'))
+    return nil
+  end
+  if vocabulary == 'unknown' then
+    emit(case(id, 'skip', string.format('unrecognised `$schema` (%s)', detail),
+      'conformance', 'schema-version-unknown'))
+    return nil
+  end
+  if vocabulary == 'missing' then
+    -- Advisory rather than a failure. The schema is still usable, but Quarto
+    -- Wizard defaults an undeclared `$schema` to v1 while this runner reads
+    -- it as v2, so the two consumers of one file can disagree until it is
+    -- declared. That is worth reporting and not worth failing over.
+    emit(advisory('conformance/schema-version/' .. ext.name,
+      string.format('the schema declares no `$schema`; add `$schema: %s`', schema.SCHEMA_VERSION)))
+  end
+
+  local loaded, load_err = schema.load_schema(path)
+  if not loaded then
+    emit(case(id, 'fail', load_err, 'conformance', 'schema-unloadable'))
+    return nil
+  end
+  emit(case(id, 'pass'))
+
+  M.check_descriptors(ext, loaded, severity, emit)
+
+  -- An empty configuration must validate. This is where a `default` whose
+  -- type contradicts its own declaration surfaces, and it is the check that
+  -- protects every extension reading its defaults back out of the schema.
+  local empty_id = 'conformance/defaults/' .. ext.name
+  local valid, errors = schema.validate({}, loaded.options, { unknown = 'ignore' })
+  if valid then
+    emit(case(empty_id, 'pass'))
+  else
+    emit(case(empty_id, 'fail',
+      'an empty configuration is rejected by the schema: ' .. table.concat(util.sorted_messages(errors), ' | '),
+      'conformance', 'defaults-invalid'))
+  end
+
+  return loaded
+end
+
+--- Walk every descriptor in a loaded schema, checking keywords, types and
+--- patterns. Iteration order comes from `schema.key_order`, so findings are
+--- reported in declaration order and two runs produce identical output.
+--- @param ext table
+--- @param loaded table
+--- @param severity string strict fails on an uncompilable pattern; lenient advises
+--- @param emit function
+function M.check_descriptors(ext, loaded, severity, emit)
+  local seen_problem = false
+
+  local function fail(id, message, reason)
+    seen_problem = true
+    emit(case(id, 'fail', message, 'conformance', reason))
+  end
+
+  local function check_descriptor(path, descriptor)
+    if type(descriptor) ~= 'table' then
+      return
+    end
+    for _, keyword in ipairs(schema.key_order(descriptor)) do
+      if schema.KEYWORDS[keyword] == nil then
+        fail('conformance/keyword/' .. ext.name .. '/' .. path .. '/' .. keyword,
+          string.format('`%s` declares the unknown keyword `%s`', path, keyword),
+          'unknown-keyword')
+      end
+    end
+
+    local declared = descriptor.type
+    local types = type(declared) == 'table' and declared or { declared }
+    for _, name in ipairs(types) do
+      if name ~= nil and not V2_TYPES[name] then
+        fail('conformance/type/' .. ext.name .. '/' .. path,
+          string.format('`%s` declares the unknown type `%s`', path, tostring(name)),
+          'unknown-type')
+      end
+    end
+
+    for _, keyword in ipairs({ 'pattern', 'propertyNames' }) do
+      local pattern = descriptor[keyword]
+      if type(pattern) == 'string' then
+        local compiled, compile_err = schema._compile_pattern(pattern)
+        if not compiled then
+          -- Strict is the author's own CI, where a pattern this validator
+          -- cannot express means runtime validation silently degrades.
+          -- Lenient is the catalogue sweep, where a legal regex the Lua
+          -- compiler simply cannot express is not the author's fault.
+          local pattern_id = 'conformance/pattern/' .. ext.name .. '/' .. path .. '/' .. keyword
+          local message = string.format('`%s.%s` does not compile: %s', path, keyword, tostring(compile_err))
+          if severity == 'strict' then
+            fail(pattern_id, message, 'pattern-uncompilable')
+          else
+            emit(advisory(pattern_id, message))
+          end
+        end
+      end
+    end
+
+    -- A declared example that its own descriptor rejects is documentation
+    -- that has drifted from the constraint beside it.
+    if type(descriptor.examples) == 'table' then
+      for index, example in ipairs(descriptor.examples) do
+        local valid = schema.validate({ probe = example }, { probe = descriptor }, { unknown = 'ignore' })
+        if not valid then
+          fail('conformance/example/' .. ext.name .. '/' .. path .. '/' .. index,
+            string.format('`%s.examples[%d]` does not satisfy its own descriptor', path, index),
+            'example-invalid')
+        end
+      end
+    end
+
+    if descriptor.const ~= nil then
+      local valid = schema.validate({ probe = descriptor.const }, { probe = descriptor }, { unknown = 'ignore' })
+      if not valid then
+        fail('conformance/const/' .. ext.name .. '/' .. path,
+          string.format('`%s.const` does not satisfy its own descriptor', path), 'const-invalid')
+      end
+    end
+
+    if type(descriptor.properties) == 'table' then
+      for _, key in ipairs(schema.key_order(descriptor.properties)) do
+        check_descriptor(path .. '.' .. key, descriptor.properties[key])
+      end
+    end
+    if type(descriptor.items) == 'table' then
+      check_descriptor(path .. '.items', descriptor.items)
+    end
+  end
+
+  local function check_map(section, map)
+    if type(map) ~= 'table' then
+      return
+    end
+    for _, key in ipairs(schema.key_order(map)) do
+      check_descriptor(section .. '.' .. key, map[key])
+    end
+  end
+
+  check_map('options', loaded.options)
+  check_map('classes', loaded.classes)
+
+  for _, name in ipairs(schema.key_order(loaded.formats or {})) do
+    check_map('formats.' .. name, loaded.formats[name])
+  end
+  for _, group in ipairs(schema.key_order(loaded.attributes or {})) do
+    check_map('attributes.' .. group, loaded.attributes[group])
+    local lowered = tostring(group):lower()
+    if group ~= '_any' and not ELEMENTS[lowered] and not tostring(group):match('^[A-Za-z_][A-Za-z0-9_-]*$') then
+      fail('conformance/attribute-group/' .. ext.name .. '/' .. group,
+        string.format('`attributes.%s` is neither `_any`, a Pandoc element, nor a class or ID token', group),
+        'attribute-group-unrecognised')
+    end
+  end
+
+  for _, name in ipairs(schema.key_order(loaded.shortcodes or {})) do
+    local entry = loaded.shortcodes[name]
+    if type(entry) == 'table' then
+      for _, key in ipairs(schema.key_order(entry)) do
+        if not SHORTCODE_KEYS[key] then
+          fail('conformance/shortcode-key/' .. ext.name .. '/' .. name .. '/' .. key,
+            string.format('`shortcodes.%s` declares the unexpected key `%s`', name, key),
+            'shortcode-key-unexpected')
+        end
+      end
+
+      for index, argument in ipairs(entry.arguments or {}) do
+        if type(argument) ~= 'table' or type(argument.name) ~= 'string' then
+          fail('conformance/argument/' .. ext.name .. '/' .. name .. '/' .. index,
+            string.format('`shortcodes.%s.arguments[%d]` has no `name`', name, index),
+            'argument-unnamed')
+        else
+          check_descriptor('shortcodes.' .. name .. '.arguments.' .. argument.name, argument)
+        end
+      end
+
+      check_map('shortcodes.' .. name .. '.attributes', entry.attributes)
+
+      for _, required in ipairs(entry.required or {}) do
+        local attributes = entry.attributes or {}
+        if attributes[required] == nil then
+          fail('conformance/required/' .. ext.name .. '/' .. name .. '/' .. tostring(required),
+            string.format('`shortcodes.%s.required` names `%s`, which is not declared in `attributes`',
+              name, tostring(required)),
+            'required-undeclared')
+        end
+      end
+    end
+  end
+
+  if not seen_problem then
+    emit(case('conformance/descriptors/' .. ext.name, 'pass'))
+  end
+end
+
+--- The manifest file name an extension declares its vendored files in.
+local DEPENDENCIES_FILE = '_dependencies.yml'
+
+--- The manifest format version this runner reads.
+local DEPENDENCIES_VERSION = 1
+
+--- The keys a source declaration may carry.
+---
+--- The validator reports an unknown key in the top-level map only, so a key
+--- inside a source or a file entry is accepted in silence. The format is
+--- public and written by hand, and `runtimes:` written for `runtime:` would
+--- otherwise disable the tripwire and say nothing. The report is an advisory,
+--- because a later version of the format may add a key this list has not
+--- heard of yet.
+local SOURCE_KEYS = { 'origin', 'fetch', 'version', 'licence', 'licence-url', 'files' }
+
+--- The keys a file entry may carry.
+local FILE_KEYS = { 'sha256', 'runtime' }
+
+--- The directory vendored files are written into, one subdirectory per source.
+local VENDOR_DIR = '_vendor'
+
+--- The names a source's licence file may carry.
+---
+--- Both spellings are here. This project writes British English, and the
+--- upstreams it vendors from overwhelmingly ship the American one. A licence
+--- under any of these names satisfies the licence check and is not an
+--- undeclared file.
+local LICENCE_FILES = {
+  'LICENSE', 'LICENSE.md', 'LICENSE.txt',
+  'LICENCE', 'LICENCE.md', 'LICENCE.txt',
+  'COPYING',
+}
+
+--- Whether a vendor directory entry is a source's licence file.
+---
+--- The names are matched without regard to case. Upstreams ship `license` in
+--- lower case as readily as `LICENSE`, and the format offers no way to say
+--- which. An exact comparison also made the verdict depend on the machine: a
+--- case-insensitive filesystem accepted what a case-sensitive one refused, so
+--- the same repository passed on macOS and failed on the Linux runner.
+---
+--- The licence check and the orphan check both read this. A name that
+--- satisfies the one is never an undeclared file to the other.
+--- @param name string a directory entry, as the filesystem spells it
+--- @return boolean
+local function is_licence_file(name)
+  local lowered = string.lower(name)
+  for _, licence in ipairs(LICENCE_FILES) do
+    if lowered == string.lower(licence) then
+      return true
+    end
+  end
+  return false
+end
+
+--- Check one extension's `_dependencies.yml`.
+---
+--- An extension with no manifest is skipped, not failed. The catalogued
+--- extensions belong to other people, and declaring nothing is not a defect.
+--- @param ext table {name, dir}
+--- @param dependencies_schema table descriptors from dependencies-schema.yml
+--- @param emit function(case)
+--- @return table|nil parsed manifest
+local function check_dependencies(ext, dependencies_schema, emit)
+  local path = util.join(ext.dir, DEPENDENCIES_FILE)
+  local id = 'conformance/vendored/' .. ext.name
+
+  if not util.exists(path) then
+    emit(case(id, 'skip', 'the extension declares no vendored dependency',
+      'conformance', 'no-dependency-manifest'))
+    return nil
+  end
+
+  local text, read_err = util.read_file(path)
+  if not text then
+    emit(case(id, 'fail', read_err, 'conformance', 'dependencies-unreadable'))
+    return nil
+  end
+
+  local parsed = schema._parse_yaml_text(text)
+  if type(parsed) ~= 'table' then
+    emit(case(id, 'fail', 'the manifest is not a YAML mapping',
+      'conformance', 'dependencies-unparseable'))
+    return nil
+  end
+
+  -- Read the version before validating against descriptors that describe one
+  -- version of the format. A manifest written to a later version is skipped,
+  -- the way an unrecognised schema vocabulary is, because every copy of this
+  -- framework already released would otherwise report a future format as the
+  -- author's defect.
+  --
+  -- Only a whole number that is not 1 is a version from the future. `schema`
+  -- is required, so a value that is absent, fractional or not a number at all
+  -- is a malformed manifest, and it falls through to the validator below,
+  -- which says so. Skipping it would take every checksum, licence and orphan
+  -- check for that extension with it.
+  --
+  -- The version is read the way the validator reads it, through a numeric
+  -- coercion, because the validator accepts a quoted scalar for an integer.
+  -- Reading `schema: "2"` any other way would walk a manifest from the future
+  -- as if it were version 1.
+  local declared_version = tonumber(parsed.schema)
+  if declared_version ~= nil
+    and (declared_version ~= declared_version
+      or declared_version == math.huge
+      or declared_version == -math.huge) then
+    -- `inf`, `-inf` and NaN are not whole numbers in any useful sense, and the
+    -- vendored validator's own integer test rejects them too. Without this,
+    -- `schema: 1e999` reads as a version from the future and skips every
+    -- checksum, licence and orphan check silently, instead of failing the
+    -- typo it is.
+    declared_version = nil
+  end
+  local from_the_future = declared_version ~= nil
+    and declared_version == math.floor(declared_version)
+    and declared_version ~= DEPENDENCIES_VERSION
+  if from_the_future then
+    emit(case(id, 'skip', string.format(
+      'the manifest declares format version %s; this runner reads version %d',
+      tostring(parsed.schema), DEPENDENCIES_VERSION),
+      'conformance', 'dependency-schema-version-unknown'))
+    return nil
+  end
+
+  local valid, errors, warnings = schema.validate(parsed, dependencies_schema, { unknown = 'warn' })
+  if not valid then
+    emit(case(id, 'fail', table.concat(util.sorted_messages(errors), '; '),
+      'conformance', 'dependencies-invalid'))
+    return nil
+  end
+  emit(case(id, 'pass'))
+  for index, warning in ipairs(util.sorted_messages(warnings)) do
+    emit(advisory(string.format('%s/warning/%d', id, index), warning))
+  end
+
+  --- Check one source: its licence, the files it declares, and its orphans.
+  ---
+  --- The caller guards the shape this reads. `M.run` continues with empty
+  --- descriptors when it cannot read its own, and then nothing has validated
+  --- the manifest before it is walked.
+  local function check_source(source_name, source)
+    local dir = util.join(ext.dir, VENDOR_DIR, source_name)
+
+    for _, key in ipairs(util.sorted_keys(source)) do
+      if not util.contains(SOURCE_KEYS, key) then
+        emit(advisory(string.format('%s/%s/unknown-key/%s', id, source_name, key),
+          string.format('`sources.%s` declares the unrecognised key `%s`', source_name, key)))
+      end
+    end
+
+    -- Third-party source shipped inside an extension carries its licence.
+    --
+    -- The directory is read, rather than probed once for each name, because a
+    -- probe answers from the filesystem's own idea of case and accepts on
+    -- macOS what it refuses on Linux. Reading the entries the directory holds
+    -- gives the same verdict on either machine, and gives the orphan check
+    -- below the very names this check has already accepted.
+    local licence_id = string.format('%s/%s/source-licence', id, source_name)
+    local licence_present = false
+    for _, present in ipairs(util.list_dir(dir)) do
+      if is_licence_file(present) then
+        licence_present = true
+      end
+    end
+    if licence_present then
+      emit(case(licence_id, 'pass'))
+    else
+      emit(case(licence_id, 'fail', string.format(
+        '`%s/%s/` ships no licence file for `%s`; name it one of %s',
+        VENDOR_DIR, source_name, source_name, table.concat(LICENCE_FILES, ', ')),
+        'conformance', 'vendored-licence-missing'))
+    end
+
+    --- Check one declared file: its keys, its presence and its checksum.
+    ---
+    --- The entry's shape is guarded here, not by the caller. Nothing has
+    --- validated the manifest when the descriptors did not load, and reading
+    --- `entry.sha256` off a number raises and takes the whole run with it.
+    local function check_file(file_name, entry)
+      local file_id = string.format('%s/%s/%s', id, source_name, file_name)
+      local file_path = util.join(dir, file_name)
+
+      if type(entry) ~= 'table' then
+        emit(case(file_id, 'fail', string.format(
+          '`sources.%s.files.%s` is not a file entry carrying a checksum',
+          source_name, file_name), 'conformance', 'dependencies-invalid'))
+        return
+      end
+
+      for _, key in ipairs(util.sorted_keys(entry)) do
+        if not util.contains(FILE_KEYS, key) then
+          emit(advisory(string.format('%s/unknown-key/%s', file_id, key), string.format(
+            '`sources.%s.files.%s` declares the unrecognised key `%s`',
+            source_name, file_name, key)))
+        end
+      end
+
+      if not util.exists(file_path) then
+        emit(case(file_id, 'fail', string.format(
+          'the manifest declares `%s`, which `%s/%s/` does not hold',
+          file_name, VENDOR_DIR, source_name), 'conformance', 'vendored-file-missing'))
+      else
+        local digest, digest_err = util.sha256(file_path)
+        if digest_err == 'no-tool' then
+          -- Neither hashing tool is available. A checksum that cannot be
+          -- computed is not a checksum that does not match.
+          emit(advisory(file_id, string.format(
+            'cannot verify `%s`: no SHA-256 tool is available', file_name)))
+        elseif not digest then
+          -- The machine has a tool and it produced nothing, so the entry
+          -- names something that is not a readable file.
+          emit(case(file_id, 'fail', string.format(
+            'the manifest declares `%s`, which `%s/%s/` holds as something no SHA-256 tool can read',
+            file_name, VENDOR_DIR, source_name), 'conformance', 'vendored-checksum-unreadable'))
+        elseif digest ~= tostring(entry.sha256):lower() then
+          emit(case(file_id, 'fail', string.format(
+            '`%s` does not match the checksum the manifest records; it reads %s',
+            file_name, digest), 'conformance', 'vendored-checksum-mismatch'))
+        else
+          emit(case(file_id, 'pass'))
+        end
+      end
+
+      if entry.runtime == 'pandoc' then
+        -- A tripwire, not a check. q2 builds Lua for wasm, where the libraries
+        -- Pandoc provides are unavailable, and q2 has not shipped.
+        emit(advisory(file_id .. '/runtime', string.format(
+          '`%s` declares `runtime: pandoc`, so it cannot load where only a plain Lua is available',
+          file_name)))
+      end
+    end
+
+    for _, file_name in ipairs(util.sorted_keys(source.files)) do
+      check_file(file_name, source.files[file_name])
+    end
+
+    -- The check aimed at the copying habit: a file that reached the vendor
+    -- directory without passing through the manifest.
+    if util.is_dir(dir) then
+      for _, present in ipairs(util.list_dir(dir)) do
+        if not is_licence_file(present) and source.files[present] == nil then
+          emit(case(string.format('%s/%s/%s', id, source_name, present), 'fail',
+            string.format('`%s/%s/%s` is not declared by the manifest',
+              VENDOR_DIR, source_name, present),
+            'conformance', 'vendored-undeclared'))
+        end
+      end
+    end
+  end
+
+  -- An id of its own. The manifest's own id has already been written above,
+  -- and one id on two cases loses one of them for every reader that keys on
+  -- the id.
+  if type(parsed.sources) ~= 'table' then
+    emit(case(id .. '/sources', 'fail', '`sources` is not a map of source declarations',
+      'conformance', 'dependencies-invalid'))
+    return nil
+  end
+
+  for _, source_name in ipairs(util.sorted_keys(parsed.sources)) do
+    local source = parsed.sources[source_name]
+    if type(source) ~= 'table' or type(source.files) ~= 'table' then
+      emit(case(string.format('%s/%s/declaration', id, source_name), 'fail',
+        string.format('`sources.%s` is not a source declaration carrying a `files` map', source_name),
+        'conformance', 'dependencies-invalid'))
+    else
+      check_source(source_name, source)
+    end
+  end
+
+  -- The loop above only ever lists the directories the manifest names, so a
+  -- whole source copied in by hand is invisible to it. Listing the vendor
+  -- directory itself is what catches that, and a loose file at its root with
+  -- it: a source is a directory the manifest declares, and nothing else
+  -- belongs here.
+  local vendor_root = util.join(ext.dir, VENDOR_DIR)
+  if util.is_dir(vendor_root) then
+    for _, present in ipairs(util.list_dir(vendor_root)) do
+      local root_id = string.format('%s/%s', id, present)
+      if parsed.sources[present] == nil then
+        emit(case(root_id, 'fail',
+          string.format('`%s/%s` is not a source the manifest declares', VENDOR_DIR, present),
+          'conformance', 'vendored-undeclared'))
+      elseif not util.is_dir(util.join(vendor_root, present)) then
+        -- A name the manifest does declare, written as a file. The verdict is
+        -- the same failure, and the sentence above is not: telling the author
+        -- the manifest does not declare it contradicts the file they wrote.
+        emit(case(root_id, 'fail', string.format(
+          'the manifest declares `%s` as a source, so `%s/%s` must be a directory, and it is a file',
+          present, VENDOR_DIR, present),
+          'conformance', 'vendored-source-not-a-directory'))
+      end
+    end
+  end
+
+  return parsed
+end
+
+--- Load each extension's manifest and schema without reporting on them.
+---
+--- The smoke layer needs both, and asking for it without the conformance
+--- layer used to leave every extension without a schema and skip silently.
+--- @param root string
+--- @return table[] extensions
+function M.load(root)
+  local extensions = M.discover(root)
+  for _, ext in ipairs(extensions) do
+    local text = util.read_file(util.join(ext.dir, '_extension.yml'))
+    if text then
+      local ok, parsed = pcall(schema._parse_yaml_text, text)
+      ext.manifest = (ok and type(parsed) == 'table') and parsed or nil
+    end
+    local path = find_schema(ext.dir)
+    if path and schema_vocabulary(path) == 'v2' then
+      ext.schema = schema.load_schema(path)
+    end
+  end
+  return extensions
+end
+
+--- Run the conformance layer over a repository.
+--- @param options table {root, severity, module_dir}
+--- @param emit function(case)
+--- @return table[] extensions, each with its loaded schema attached
+function M.run(options, emit)
+  local manifest_path = util.join(options.extension_dir, 'manifest-schema.yml')
+  local manifest_schema = {}
+  local loaded_manifest, manifest_err = schema.load_schema(manifest_path)
+  if loaded_manifest then
+    manifest_schema = loaded_manifest.options
+  else
+    emit(case('conformance/harness/manifest-schema', 'fail',
+      'the framework cannot read its own manifest descriptors: ' .. tostring(manifest_err),
+      'discover', 'harness-error'))
+  end
+
+  local dependencies_schema = {}
+  local loaded_dependencies, dependencies_err =
+    schema.load_schema(util.join(options.extension_dir, 'dependencies-schema.yml'))
+  if loaded_dependencies then
+    dependencies_schema = loaded_dependencies.options
+  else
+    emit(case('conformance/harness/dependencies-schema', 'fail',
+      'the framework cannot read its own dependency descriptors: ' .. tostring(dependencies_err),
+      'discover', 'harness-error'))
+  end
+
+  local extensions = M.discover(options.root)
+  if #extensions == 0 then
+    emit(case('conformance/discover', 'skip',
+      string.format('no extension found under `%s/_extensions/`', options.root),
+      'discover', 'no-extension'))
+    return {}
+  end
+
+  for _, ext in ipairs(extensions) do
+    ext.manifest = check_manifest(ext, manifest_schema, emit)
+    ext.schema = check_schema(ext, options.severity, emit)
+    ext.dependencies = check_dependencies(ext, dependencies_schema, emit)
+  end
+
+  return extensions
+end
+
+--- Exposed for the framework's own tests.
+---
+--- The licence rule is a rule about names, and a fixture can only ask the
+--- filesystem it runs on. A case-insensitive one answers for `LICENSE` when
+--- the directory holds `license`, and hides half the rule. This reads the name
+--- alone, so the tests assert the rule on either machine.
+M._is_licence_file = is_licence_file
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/emit.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/emit.lua
@@ -1,0 +1,207 @@
+--- Extension Test - Turning derived values into Quarto source.
+---
+--- One distinction runs through this module. A document option is a real YAML
+--- value, so a boolean is written `true`. A Pandoc attribute always arrives as
+--- text, so the same boolean is written `"true"`. Schemas in the wild type the
+--- two levels differently for exactly this reason, and collapsing them would
+--- emit values the extension's own schema rejects.
+
+local schema = require('schema')
+
+local M = {}
+
+--- Characters that force a YAML scalar to be quoted.
+local NEEDS_QUOTE = '[:#{}%[%],&%*!|>\'"%%@`]'
+
+--- Whether a string would parse as something other than a string.
+local function looks_typed(value)
+  return value:match('^%-?%d+%.?%d*$') ~= nil
+    or value == 'true' or value == 'false'
+    or value == 'null' or value == '~' or value == ''
+    or value:match('^%s') ~= nil or value:match('%s$') ~= nil
+end
+
+--- Render a scalar as YAML.
+--- @param value any
+--- @return string
+function M.scalar(value)
+  local kind = type(value)
+  if kind == 'boolean' then
+    return tostring(value)
+  elseif kind == 'number' then
+    if value == math.floor(value) and math.abs(value) < 2 ^ 53 then
+      return string.format('%d', value)
+    end
+    return tostring(value)
+  elseif kind == 'nil' then
+    return 'null'
+  end
+  local text = tostring(value)
+  if text:match(NEEDS_QUOTE) or looks_typed(text) then
+    return '"' .. text:gsub('\\', '\\\\'):gsub('"', '\\"') .. '"'
+  end
+  return text
+end
+
+--- Render a value as YAML at a given indentation.
+--- @param value any
+--- @param indent integer number of spaces
+--- @return string
+function M.yaml(value, indent)
+  indent = indent or 0
+  local pad = string.rep(' ', indent)
+
+  if type(value) ~= 'table' then
+    return M.scalar(value)
+  end
+
+  if #value > 0 then
+    local lines = {}
+    for _, item in ipairs(value) do
+      if type(item) == 'table' then
+        lines[#lines + 1] = pad .. '-\n' .. M.yaml(item, indent + 2)
+      else
+        lines[#lines + 1] = pad .. '- ' .. M.scalar(item)
+      end
+    end
+    return table.concat(lines, '\n')
+  end
+
+  local lines = {}
+  for _, key in ipairs(schema.key_order(value)) do
+    local child = value[key]
+    if type(child) == 'table' then
+      local nested = M.yaml(child, indent + 2)
+      if nested == '' then
+        lines[#lines + 1] = pad .. key .. ': {}'
+      else
+        lines[#lines + 1] = pad .. key .. ':\n' .. nested
+      end
+    else
+      lines[#lines + 1] = pad .. key .. ': ' .. M.scalar(child)
+    end
+  end
+  return table.concat(lines, '\n')
+end
+
+--- Render a value as a Pandoc attribute, which is always text.
+--- @param value any
+--- @return string
+function M.attribute_value(value)
+  if type(value) == 'table' then
+    local parts = {}
+    for _, item in ipairs(value) do
+      parts[#parts + 1] = tostring(item)
+    end
+    return table.concat(parts, ' ')
+  end
+  return tostring(value)
+end
+
+--- Render an attribute list, in declaration order.
+--- @param attributes table
+--- @param order string[]|nil
+--- @return string
+function M.attributes(attributes, order)
+  local parts = {}
+  for _, key in ipairs(order or schema.key_order(attributes)) do
+    if attributes[key] ~= nil then
+      local text = M.attribute_value(attributes[key]):gsub('"', '\\"')
+      parts[#parts + 1] = string.format('%s="%s"', key, text)
+    end
+  end
+  return table.concat(parts, ' ')
+end
+
+--- Render a shortcode call.
+---
+--- Emitted inside a paragraph, never inside a code block, where Quarto would
+--- not expand it and the surviving-text check would report a false failure.
+--- @param name string
+--- @param positional any[]
+--- @param attributes table|nil
+--- @param order string[]|nil attribute order
+--- @return string
+function M.shortcode(name, positional, attributes, order)
+  local parts = { name }
+  for _, value in ipairs(positional or {}) do
+    local text = M.attribute_value(value)
+    if text == '' or text:match('[%s>"]') then
+      parts[#parts + 1] = '"' .. text:gsub('"', '\\"') .. '"'
+    else
+      parts[#parts + 1] = text
+    end
+  end
+  local rendered = M.attributes(attributes or {}, order)
+  if rendered ~= '' then
+    parts[#parts + 1] = rendered
+  end
+  return '{{< ' .. table.concat(parts, ' ') .. ' >}}'
+end
+
+--- Render a fenced Div carrying classes and attributes.
+--- @param classes string[]
+--- @param attributes table|nil
+--- @param body string
+--- @param identifier string|nil
+--- @return string
+function M.div(classes, attributes, body, identifier)
+  local parts = {}
+  if identifier then
+    parts[#parts + 1] = '#' .. identifier
+  end
+  for _, class in ipairs(classes or {}) do
+    parts[#parts + 1] = '.' .. class
+  end
+  local rendered = M.attributes(attributes or {})
+  if rendered ~= '' then
+    parts[#parts + 1] = rendered
+  end
+  return string.format('::: {%s}\n%s\n:::', table.concat(parts, ' '), body)
+end
+
+--- Render a bracketed Span.
+--- @param classes string[]
+--- @param attributes table|nil
+--- @param body string
+--- @param identifier string|nil
+--- @return string
+function M.span(classes, attributes, body, identifier)
+  local parts = {}
+  if identifier then
+    parts[#parts + 1] = '#' .. identifier
+  end
+  for _, class in ipairs(classes or {}) do
+    parts[#parts + 1] = '.' .. class
+  end
+  local rendered = M.attributes(attributes or {})
+  if rendered ~= '' then
+    parts[#parts + 1] = rendered
+  end
+  return string.format('[%s]{%s}', body, table.concat(parts, ' '))
+end
+
+--- Assemble a document from front matter and a body.
+--- @param front table
+--- @param body string[]
+--- @param note string
+--- @return string
+function M.document(front, body, note)
+  local lines = { '---' }
+  local rendered = M.yaml(front, 0)
+  if rendered ~= '' then
+    lines[#lines + 1] = rendered
+  end
+  lines[#lines + 1] = '---'
+  lines[#lines + 1] = ''
+  -- A generated file found loose in a working tree should explain itself.
+  lines[#lines + 1] = '<!-- ' .. note .. ' -->'
+  lines[#lines + 1] = ''
+  for _, chunk in ipairs(body) do
+    lines[#lines + 1] = chunk
+    lines[#lines + 1] = ''
+  end
+  return table.concat(lines, '\n')
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/frontmatter.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/frontmatter.lua
@@ -1,0 +1,116 @@
+--- Extension Test - Reading the `test:` block from a document.
+---
+--- The vocabulary is additive only. The catalogue sweep runs one pinned
+--- framework version against repositories that pinned an older one, so a key
+--- this version does not recognise is reported as a warning and ignored,
+--- never as a failure.
+
+local util = require('util')
+local schema = require('schema')
+
+local M = {}
+
+--- Defaults applied when a document declares nothing.
+M.DEFAULTS = {
+  schema = 1,
+  expect = 'pass',
+  strict = true,
+  timeout = 300,
+  skip = false,
+}
+
+--- Extract the YAML front matter of a document.
+---
+--- Only a block opened by `---` on the first non-empty line counts, which is
+--- what Quarto itself accepts.
+--- @param text string
+--- @return string|nil yaml
+local function front_matter_text(text)
+  local body = text:gsub('^\239\187\191', '')
+  local block = body:match('^%-%-%-\r?\n(.-)\r?\n%-%-%-%s*\r?\n')
+    or body:match('^%-%-%-\r?\n(.-)\r?\n%.%.%.%s*\r?\n')
+  return block
+end
+
+--- Read and validate a document's `test:` block.
+--- @param path string document path
+--- @param descriptors table descriptors from test-schema.yml
+--- @param defaults table|nil project-level defaults from tests/_quarto.yml
+--- @return table settings
+--- @return string[] warnings
+function M.read(path, descriptors, defaults)
+  local warnings = {}
+  local text, read_err = util.read_file(path)
+  if not text then
+    return M.DEFAULTS, { tostring(read_err) }
+  end
+
+  local block = front_matter_text(text)
+  local declared = {}
+  if block then
+    local ok, parsed = pcall(schema._parse_yaml_text, block)
+    if ok and type(parsed) == 'table' and type(parsed.test) == 'table' then
+      declared = parsed.test
+    elseif ok and type(parsed) == 'table' and parsed.test ~= nil then
+      warnings[#warnings + 1] = 'the `test:` key is not a mapping and was ignored'
+    end
+  end
+
+  -- Project-level defaults lose to the document, key by key.
+  local merged = {}
+  for key, value in pairs(defaults or {}) do
+    merged[key] = value
+  end
+  for key, value in pairs(declared) do
+    merged[key] = value
+  end
+
+  local _, errors, validation_warnings, coerced =
+    schema.validate(merged, descriptors, { unknown = 'warn' })
+  -- Reported, not fatal: a `test:` block this version cannot read must not
+  -- stop the catalogue sweep from testing the extension at all. Sorted so a
+  -- document with several problems reports them in the same order every run.
+  for _, message in ipairs(util.sorted_messages(errors)) do
+    warnings[#warnings + 1] = message
+  end
+  for _, message in ipairs(util.sorted_messages(validation_warnings)) do
+    warnings[#warnings + 1] = message
+  end
+
+  local settings = {}
+  for key, value in pairs(M.DEFAULTS) do
+    settings[key] = value
+  end
+  for key, value in pairs(coerced or merged) do
+    settings[key] = value
+  end
+
+  if type(settings.formats) == 'string' then
+    settings.formats = { settings.formats }
+  end
+  settings.name = settings.name or pandoc.path.filename(path):gsub('%.qmd$', '')
+
+  return settings, warnings
+end
+
+--- Read project-level `test:` defaults from a tests project file.
+--- @param tests string tests directory
+--- @return table defaults
+function M.project_defaults(tests)
+  for _, name in ipairs({ '_quarto.yml', '_quarto.yaml' }) do
+    local path = util.join(tests, name)
+    if util.exists(path) then
+      local text = util.read_file(path)
+      if text then
+        local ok, parsed = pcall(schema._parse_yaml_text, text)
+        if ok and type(parsed) == 'table' and type(parsed.test) == 'table' then
+          return parsed.test
+        end
+      end
+      return {}
+    end
+  end
+  return {}
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/generate.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/generate.lua
@@ -1,0 +1,371 @@
+--- Extension Test - Layer C, generated smoke.
+---
+--- Synthesises documents from what `_schema.yml` already declares: the
+--- options, shortcodes, element attributes, classes and formats an extension
+--- contributes. An extension that ships a schema therefore gains coverage
+--- without writing a single test.
+---
+--- What a pass means here is narrow and worth stating plainly. The document
+--- was generated, it rendered, no error was logged, no promoted warning
+--- appeared, and no shortcode text survived into the output. Nothing about
+--- the content of the output is asserted. Authored assertions are v2.
+
+local util = require('util')
+local schema = require('schema')
+local values = require('values')
+local emit = require('emit')
+
+local M = {}
+
+--- Documents generated per extension before the run gives up.
+---
+--- A pathological schema degrades into a reported cap rather than a hang.
+M.DEFAULT_CAP = 200
+
+--- How a generated document has to name the extension so Quarto loads it.
+---
+--- Only a shortcode is resolved without being asked for. Every other kind of
+--- contribution needs the document to name it, and a generated document that
+--- does not is rendered with the extension absent: it passes while proving
+--- nothing, which is the failure this whole layer exists to catch.
+---
+--- A contributed format is consumed as `<extension>-<base>`, not as the bare
+--- base name, so `contributes.formats: {pdf: ...}` on an extension named
+--- `letter` is reached as `letter-pdf`.
+--- @param ext_name string
+--- @param manifest table parsed `_extension.yml`
+--- @return table wiring {formats, filters, plugins}
+local function contribution_wiring(ext_name, manifest)
+  local contributes = (manifest or {}).contributes or {}
+  local wiring = { formats = {}, filters = {}, plugins = {} }
+
+  if type(contributes.formats) == 'table' then
+    for _, key in ipairs(schema.key_order(contributes.formats)) do
+      if key ~= 'common' then
+        wiring.formats[#wiring.formats + 1] = ext_name .. '-' .. key
+      end
+    end
+  end
+
+  if type(contributes.filters) == 'table' and #contributes.filters > 0 then
+    wiring.filters[#wiring.filters + 1] = ext_name
+  end
+
+  if type(contributes['revealjs-plugins']) == 'table' and #contributes['revealjs-plugins'] > 0 then
+    wiring.plugins[#wiring.plugins + 1] = ext_name
+    wiring.formats[#wiring.formats + 1] = 'revealjs'
+  end
+
+  if #wiring.formats == 0 then
+    wiring.formats[1] = 'html'
+  end
+
+  return wiring
+end
+
+--- Front matter shared by every generated document.
+---
+--- The wiring is repeated on every document rather than set once in the test
+--- project, because each document is rendered on its own by explicit path.
+--- @param title string
+--- @param wiring table
+--- @return table
+local function front_matter(title, wiring)
+  local front = { title = title }
+  local rendered = {}
+  for _, format in ipairs(wiring.formats) do
+    rendered[format] = {}
+  end
+  front.format = rendered
+  if #wiring.filters > 0 then
+    front.filters = wiring.filters
+  end
+  if #wiring.plugins > 0 then
+    front['revealjs-plugins'] = wiring.plugins
+  end
+  front.test = { formats = wiring.formats }
+  return front
+end
+
+--- A generated document waiting to be written.
+local function document(name, front, body, note, kind, extension)
+  return {
+    name = name,
+    front = front,
+    body = body,
+    note = note,
+    kind = kind,
+    extension = extension,
+  }
+end
+
+--- Invocations of every declared shortcode, for use as document filler.
+--- @param loaded table
+--- @return string[]
+local function shortcode_samples(loaded)
+  local samples = {}
+  for _, name in ipairs(schema.key_order(loaded.shortcodes or {})) do
+    local entry = loaded.shortcodes[name]
+    local positional = {}
+    for _, argument in ipairs((entry or {}).arguments or {}) do
+      local value, ok = values.derive(argument)
+      if ok then
+        positional[#positional + 1] = value
+      end
+    end
+    samples[#samples + 1] = emit.shortcode(name, positional)
+  end
+  return samples
+end
+
+--- Build the documents for one extension.
+--- @param ext table {name, dir, schema}
+--- @param manifest table parsed `_extension.yml`
+--- @param cap integer
+--- @return table[] documents, table[] skips
+function M.plan(ext, manifest, cap)
+  local loaded = ext.schema
+  local documents, skips = {}, {}
+  if type(loaded) ~= 'table' then
+    return documents, skips
+  end
+
+  local wiring = contribution_wiring(ext.name, manifest)
+  local filler = shortcode_samples(loaded)
+
+  local function add(doc)
+    if #documents >= cap then
+      if #skips == 0 or skips[#skips].reason ~= 'generation-cap-reached' then
+        skips[#skips + 1] = {
+          id = 'smoke/' .. ext.name .. '/cap',
+          reason = 'generation-cap-reached',
+          message = string.format('generation stopped at %d documents for `%s`', cap, ext.name),
+        }
+      end
+      return
+    end
+    documents[#documents + 1] = doc
+  end
+
+  -- Options at their declared defaults, with nothing set. This is where an
+  -- extension that reads its defaults out of its own schema breaks when the
+  -- schema changes underneath it.
+  if next(loaded.options or {}) ~= nil then
+    add(document(
+      string.format('%s-options-defaults', ext.name),
+      front_matter('Options at their defaults', wiring),
+      filler,
+      'Generated: every option left unset, exercising the defaults path.',
+      'options', ext.name))
+
+    local derived, undecidable = values.derive_map(loaded.options)
+    for _, entry in ipairs(undecidable) do
+      skips[#skips + 1] = {
+        id = string.format('smoke/%s/options/%s', ext.name, entry.key),
+        reason = entry.reason,
+        message = entry.pattern
+          and string.format('no value satisfies `options.%s` (pattern `%s`)', entry.key, entry.pattern)
+          or string.format('no value satisfies `options.%s`', entry.key),
+      }
+    end
+    if next(derived) ~= nil then
+      local front = front_matter('Options fully set', wiring)
+      front.extensions = { [ext.name] = derived }
+      add(document(
+        string.format('%s-options-full', ext.name),
+        front, filler,
+        'Generated: every option set to a value its own descriptor accepts.',
+        'options', ext.name))
+    end
+  end
+
+  -- One document per shortcode, minimal and full.
+  for _, name in ipairs(schema.key_order(loaded.shortcodes or {})) do
+    local entry = loaded.shortcodes[name] or {}
+
+    local minimal_positional = {}
+    local minimal_ok = true
+    for _, argument in ipairs(entry.arguments or {}) do
+      if argument.required == true then
+        local value, ok = values.derive(argument)
+        if ok then
+          minimal_positional[#minimal_positional + 1] = value
+        else
+          minimal_ok = false
+        end
+      end
+    end
+    local minimal_attributes = {}
+    for _, key in ipairs(entry.required or {}) do
+      local descriptor = (entry.attributes or {})[key]
+      if type(descriptor) == 'table' then
+        local value, ok = values.derive(descriptor)
+        if ok then
+          minimal_attributes[key] = value
+        else
+          minimal_ok = false
+        end
+      end
+    end
+
+    if minimal_ok then
+      add(document(
+        string.format('%s-shortcode-%s-minimal', ext.name, tostring(name):gsub('[^%w]+', '-')),
+        front_matter(string.format('Shortcode %s, required only', name), wiring),
+        { emit.shortcode(name, minimal_positional, minimal_attributes) },
+        string.format('Generated: `%s` with its required arguments and attributes only.', name),
+        'shortcode', ext.name))
+    else
+      skips[#skips + 1] = {
+        id = string.format('smoke/%s/shortcode/%s/minimal', ext.name, name),
+        reason = 'required-field-undecidable',
+        message = string.format('a required argument or attribute of `%s` has no derivable value', name),
+      }
+    end
+
+    local full_positional = {}
+    for _, argument in ipairs(entry.arguments or {}) do
+      local value, ok = values.derive(argument)
+      if ok then
+        full_positional[#full_positional + 1] = value
+      end
+    end
+    local full_attributes, undecidable = values.derive_map(entry.attributes, function(_, descriptor)
+      return descriptor.deprecated == nil or descriptor.deprecated == false
+    end)
+    for _, item in ipairs(undecidable) do
+      skips[#skips + 1] = {
+        id = string.format('smoke/%s/shortcode/%s/%s', ext.name, name, item.key),
+        reason = item.reason,
+        message = string.format('no value satisfies `shortcodes.%s.attributes.%s`', name, item.key),
+      }
+    end
+    if #full_positional > 0 or next(full_attributes) ~= nil then
+      add(document(
+        string.format('%s-shortcode-%s-full', ext.name, tostring(name):gsub('[^%w]+', '-')),
+        front_matter(string.format('Shortcode %s, fully specified', name), wiring),
+        { emit.shortcode(name, full_positional, full_attributes) },
+        string.format('Generated: `%s` with every declared argument and attribute.', name),
+        'shortcode', ext.name))
+    end
+  end
+
+  -- Element attributes, one document per declared group.
+  for _, group in ipairs(schema.key_order(loaded.attributes or {})) do
+    local derived = values.derive_map(loaded.attributes[group])
+    if next(derived) ~= nil then
+      local body = {}
+      local lowered = tostring(group):lower()
+      local is_element = lowered == 'div' or lowered == 'span' or lowered == 'code'
+        or lowered == 'codeblock' or lowered == 'header'
+
+      if group == '_any' then
+        body[#body + 1] = emit.div({}, derived, 'Div content.')
+        body[#body + 1] = emit.span({}, derived, 'Span content.')
+        body[#body + 1] = '# Heading {' .. emit.attributes(derived) .. '}'
+      elseif is_element then
+        if lowered == 'span' or lowered == 'code' then
+          body[#body + 1] = emit.span({}, derived, 'Span content.')
+        elseif lowered == 'header' then
+          body[#body + 1] = '# Heading {' .. emit.attributes(derived) .. '}'
+        else
+          body[#body + 1] = emit.div({}, derived, 'Div content.')
+        end
+      else
+        -- A group key that is neither `_any` nor an element name may be read
+        -- as a class or as an ID prefix; the extension decides. Both are
+        -- emitted, because an attribute nothing matches is inert markup.
+        body[#body + 1] = emit.div({ group }, derived, 'Div content.')
+        body[#body + 1] = emit.div({}, derived, 'Div content.', group .. '-example')
+      end
+
+      add(document(
+        string.format('%s-attributes-%s', ext.name, tostring(group):gsub('[^%w]+', '-')),
+        front_matter(string.format('Attributes for %s', tostring(group)), wiring),
+        body,
+        string.format('Generated: the `%s` attribute group.', tostring(group)),
+        'attributes', ext.name))
+    end
+  end
+
+  -- Contributed classes.
+  local class_names = schema.key_order(loaded.classes or {})
+  if #class_names > 0 then
+    local body = {}
+    for _, class in ipairs(class_names) do
+      body[#body + 1] = emit.div({ class }, {}, string.format('Content in `.%s`.', class))
+      body[#body + 1] = emit.span({ class }, {}, 'Inline content.')
+    end
+    add(document(
+      string.format('%s-classes', ext.name),
+      front_matter('Contributed classes', wiring),
+      body,
+      'Generated: one block and one inline element per contributed class.',
+      'classes', ext.name))
+  end
+
+  -- Format-specific options, one document per declared format.
+  for _, format in ipairs(schema.key_order(loaded.formats or {})) do
+    local derived = values.derive_map(loaded.formats[format])
+    -- A `formats:` key names the base format, and the extension is reached
+    -- through its own name, so the document has to ask for `<ext>-<base>`
+    -- whenever the manifest contributes that base.
+    --- @type string
+    local target = format
+    for _, contributed in ipairs(wiring.formats) do
+      if contributed == ext.name .. '-' .. format then
+        target = contributed
+      end
+    end
+    local front = front_matter(string.format('Format %s', format),
+      { formats = { target }, filters = wiring.filters, plugins = wiring.plugins })
+    if next(derived) ~= nil then
+      front.extensions = { [ext.name] = derived }
+    end
+    add(document(
+      string.format('%s-format-%s', ext.name, tostring(format):gsub('[^%w]+', '-')),
+      front, filler,
+      string.format('Generated: the `%s` format section.', format),
+      'format', ext.name))
+  end
+
+  -- A contributed project type needs a whole nested project to exercise, so
+  -- it is named as a gap rather than half-generated.
+  for _, project in ipairs(loaded.projects or {}) do
+    skips[#skips + 1] = {
+      id = string.format('smoke/%s/project/%s', ext.name, tostring(project)),
+      reason = 'projects-not-generated',
+      message = string.format('the `%s` project type is not generated in this version', tostring(project)),
+    }
+  end
+
+  return documents, skips
+end
+
+--- Write planned documents into the generated directory.
+--- @param tests string
+--- @param documents table[]
+--- @return string dir, string[] written relative paths, string|nil error
+function M.write(tests, documents)
+  local dir = util.join(tests, 'generated')
+  util.remove_tree(dir)
+  local written = {}
+  for _, doc in ipairs(documents) do
+    local relative = 'generated/' .. doc.name .. '.qmd'
+    local text = emit.document(doc.front, doc.body, doc.note)
+    local ok, err = util.write_file(util.join(tests, relative), text)
+    if not ok then
+      return dir, written, tostring(err)
+    end
+    written[#written + 1] = relative
+  end
+  return dir, written, nil
+end
+
+--- Remove the generated directory.
+--- @param tests string
+function M.clean(tests)
+  util.remove_tree(util.join(tests, 'generated'))
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/render.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/render.lua
@@ -1,0 +1,512 @@
+--- Extension Test - Layer B, render.
+---
+--- Renders each test document to each of its formats and inspects what the
+--- render leaves behind. Exit code alone is not enough: an extension that
+--- fails to load logs a warning and still exits 0, which is precisely the
+--- breakage a Quarto update causes and precisely what every existing check
+--- in the ecosystem misses.
+
+local util = require('util')
+local stage = require('stage')
+local frontmatter = require('frontmatter')
+
+local M = {}
+
+--- Warnings that fail a case despite Quarto exiting 0.
+---
+--- Measured: an extension that is not resolved produces
+--- `WARNING ... Shortcode 'probe' not found` and `Output created`, exit 0.
+--- A blanket "warnings never fail" rule would make this layer blind to the
+--- one failure it exists to catch. Every other warning is recorded and does
+--- not fail, because extensions warn legitimately all the time.
+M.PROMOTED_WARNINGS = {
+  { pattern = "Shortcode '[^']*' not found", reason = 'shortcode-not-found' },
+  { pattern = 'Extension [^%s]* not found', reason = 'extension-not-found' },
+  { pattern = "filter '[^']*' not found", reason = 'filter-not-found' },
+}
+
+--- Markers left in output when a shortcode did not expand.
+---
+--- HTML escapes the delimiters; Typst, LaTeX and markdown do not. Both forms
+--- are checked because the same failure looks different per format.
+M.UNEXPANDED_MARKERS = { '{{<', '{{&lt;' }
+
+--- Documents that are never test inputs.
+local function is_ignored(relative)
+  return relative:match('^_')
+    or relative:match('/_')
+    or relative:match('^_extensions/')
+    or relative:match('^generated/')
+    or relative:match('^_results/')
+    or relative:match('^_output/')
+    or relative:match('^%.quarto/')
+end
+
+--- Collect `.qmd` documents under a directory, relative to it.
+--- @param base string
+--- @param prefix string|nil
+--- @param found string[]|nil
+--- @return string[]
+local function collect(base, prefix, found)
+  prefix = prefix or ''
+  found = found or {}
+  for _, name in ipairs(util.list_dir(base)) do
+    local relative = prefix == '' and name or (prefix .. '/' .. name)
+    local absolute = util.join(base, name)
+    if util.is_dir(absolute) then
+      if not is_ignored(relative .. '/') then
+        collect(absolute, relative, found)
+      end
+    elseif name:match('%.qmd$') and not is_ignored(relative) then
+      found[#found + 1] = relative
+    end
+  end
+  return found
+end
+
+--- Decide what to render.
+---
+--- A repository with no authored test document still gets a working layer
+--- from its own demo file, so `--init` alone is enough to be testing
+--- something. `docs/` is never a candidate: it documents the extension rather
+--- than exercising it, and it often stages the extension with a script this
+--- runner knows nothing about.
+--- @param root string
+--- @param tests string
+--- @return table[] documents {relative, absolute, origin}
+function M.discover(root, tests)
+  local documents = {}
+  for _, relative in ipairs(collect(tests)) do
+    documents[#documents + 1] = {
+      relative = relative,
+      absolute = util.join(tests, relative),
+      origin = 'tests',
+    }
+  end
+  if #documents > 0 then
+    return documents
+  end
+
+  for _, name in ipairs({ 'example.qmd', 'template.qmd' }) do
+    local absolute = util.join(root, name)
+    if util.exists(absolute) then
+      return { { relative = name, absolute = absolute, origin = 'demo' } }
+    end
+  end
+  return {}
+end
+
+--- Formats Quarto reports for a document.
+--- @param document string absolute path
+--- @param cwd string directory to inspect from
+--- @return string[] formats
+--- @return string|nil error
+function M.formats(document, cwd)
+  local command = string.format('cd %s && quarto inspect %s',
+    util.shell_quote(cwd), util.shell_quote(document))
+  local code, output = util.capture(command)
+  if code ~= 0 then
+    return {}, 'quarto inspect failed: ' .. util.trim(output)
+  end
+  local ok, parsed = pcall(pandoc.json.decode, output, false)
+  if not ok or type(parsed) ~= 'table' or type(parsed.formats) ~= 'table' then
+    return {}, 'quarto inspect returned no formats'
+  end
+  return util.sorted_keys(parsed.formats), nil
+end
+
+--- Scan a render log for errors and promoted warnings.
+--- @param log_path string
+--- @return string[] errors, string[] warnings, table|nil promoted
+function M.scan_log(log_path)
+  local errors, warnings = {}, {}
+  local promoted = nil
+  local text = util.read_file(log_path)
+  if not text then
+    return errors, warnings, promoted
+  end
+  for _, line in ipairs(util.lines(text)) do
+    if line:match('^ERROR') or line:match('ERROR:') then
+      errors[#errors + 1] = util.trim(line)
+    elseif line:match('WARNING') or line:match('^warning') then
+      warnings[#warnings + 1] = util.trim(line)
+      for _, rule in ipairs(M.PROMOTED_WARNINGS) do
+        if line:match(rule.pattern) and not promoted then
+          promoted = { reason = rule.reason, message = util.trim(line) }
+        end
+      end
+    end
+  end
+  return errors, warnings, promoted
+end
+
+--- The most informative line of a failed render.
+---
+--- Quarto reports a Lua failure as a message followed by a stack trace, and
+--- the trace is the least useful part. The frame naming a file inside the
+--- extension under test is the most useful, because it points at the line the
+--- author has to change, so it is preferred when present.
+--- @param output string combined command output
+--- @param errors string[] error lines already scanned from the log
+--- @return string
+function M.first_error(output, errors)
+  if #errors > 0 then
+    return errors[1]
+  end
+  local headline, frame
+  for _, line in ipairs(util.lines(output)) do
+    local trimmed = util.trim(line)
+    if trimmed ~= '' and not headline
+      and (trimmed:match('^[Ee]rror') or trimmed:match('^ERROR')) then
+      headline = trimmed
+    end
+    if not frame and trimmed:match('_extensions/') and trimmed:match(':%d+:') then
+      frame = trimmed
+    end
+  end
+  if headline and frame then
+    return headline .. ' (' .. frame .. ')'
+  end
+  return headline or frame or 'the render failed with no diagnostic output'
+end
+
+--- Whether an output file still holds unexpanded shortcode text.
+--- @param path string
+--- @return boolean
+function M.has_unexpanded(path)
+  local text = util.read_file(path)
+  if not text then
+    return false
+  end
+  for _, marker in ipairs(M.UNEXPANDED_MARKERS) do
+    if text:find(marker, 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
+--- Render one document to one format and judge the result.
+--- @param context table {tests, log_dir, settings, document}
+--- @param format string
+--- @return table case
+local function render_one(context, format)
+  local document = context.document
+  local settings = context.settings
+  local layer = context.layer or 'render'
+  local id = string.format('%s/%s/%s', layer, document.relative:gsub('%.qmd$', ''), format)
+  -- The slug is lossy, so `a/b/html` and `a-b/html` would share a file.
+  -- The sequence keeps every case's log distinct.
+  context.sequence = (context.sequence or 0) + 1
+  local slug = string.format('%03d-%s', context.sequence, id:gsub('[^%w]+', '-'))
+  local log_path = util.join(context.log_dir, slug .. '.log')
+
+  local command = string.format(
+    'cd %s && %squarto render %s --to %s --log %s --log-level info',
+    util.shell_quote(context.tests), util.timeout_prefix(settings.timeout),
+    util.shell_quote(document.absolute), util.shell_quote(format),
+    util.shell_quote(log_path))
+
+  -- A previous format wrote into the same directory. Removing the output
+  -- first means a missing file after the render is a fact, not a leftover.
+  local expected = M.output_path(context.tests, document, format)
+  if expected then
+    os.remove(expected)
+  end
+
+  local code, output = util.capture(command)
+  local errors, warnings, promoted = M.scan_log(log_path)
+
+  local case = {
+    id = id,
+    layer = layer,
+    target = {
+      kind = document.origin,
+      document = document.relative,
+      format = format,
+    },
+    diagnostics = { errors = errors, warnings = warnings },
+  }
+
+  local function fail(stage_name, reason, message)
+    case.status = 'fail'
+    case.failure = { stage = stage_name, reason = reason, message = message, log = log_path }
+  end
+
+  local expects_failure = settings.expect == 'fail'
+
+  -- A timeout is the harness giving up, not the failure the document
+  -- declares, so `expect: fail` does not turn a stall into a pass.
+  if code == 124 then
+    fail('render', 'timeout', string.format('the render exceeded %s seconds', tostring(settings.timeout)))
+    return case
+  end
+
+  if code ~= 0 then
+    if expects_failure then
+      case.status = 'pass'
+      return case
+    end
+    fail('render', 'exit ' .. tostring(code), M.first_error(output, errors))
+    return case
+  end
+
+  -- The render succeeded. Everything below is the difference between
+  -- "Quarto exited 0" and "the extension actually did something".
+  if promoted then
+    if expects_failure then
+      case.status = 'pass'
+      return case
+    end
+    fail('assert', promoted.reason, promoted.message)
+    return case
+  end
+
+  if settings.strict ~= false and #errors > 0 then
+    if expects_failure then
+      case.status = 'pass'
+      return case
+    end
+    fail('log', 'error-logged', errors[1])
+    return case
+  end
+
+  local output_path = M.output_path(context.tests, document, format)
+  if not output_path then
+    case.status = 'skip'
+    case.failure = {
+      stage = 'assert',
+      reason = 'output-not-found',
+      message = string.format('the render reported success but no `%s` output was found to check', format),
+      log = log_path,
+    }
+    return case
+  end
+  if M.has_unexpanded(output_path) then
+    if expects_failure then
+      case.status = 'pass'
+      return case
+    end
+    fail('assert', 'shortcode-not-expanded',
+      'the output still holds shortcode text, so the shortcode did not expand')
+    return case
+  end
+
+  if expects_failure then
+    case.status = 'fail'
+    case.failure = {
+      stage = 'assert',
+      reason = 'unexpected-pass',
+      message = 'the case declares `expect: fail` but the render succeeded',
+      log = log_path,
+    }
+    return case
+  end
+
+  case.status = 'pass'
+  return case
+end
+
+--- Guess where a render put its output.
+---
+--- Only used for the unexpanded-shortcode scan, so a miss costs a check
+--- rather than a false failure.
+--- @param tests string
+--- @param document table
+--- @param format string
+--- @return string|nil
+function M.output_path(tests, document, format)
+  local extensions = {
+    html = 'html', revealjs = 'html', typst = 'pdf', pdf = 'pdf',
+    docx = 'docx', gfm = 'md', markdown = 'md', commonmark = 'md',
+    latex = 'tex', beamer = 'pdf', pptx = 'pptx', epub = 'epub',
+  }
+  -- A contributed format is `<extension>-<base>`, so the trailing base name
+  -- decides the suffix. There is deliberately no fallback: guessing `.html`
+  -- finds the previous format's output in the same directory, and scanning
+  -- the wrong file gives a false pass or blames the wrong format.
+  local base = format:match('([^%-]+)$') or format
+  local suffix = extensions[format] or extensions[base]
+  if not suffix then
+    return nil
+  end
+
+  local relative = document.relative:gsub('%.qmd$', '') .. '.' .. suffix
+  local candidates = {
+    document.absolute:gsub('%.qmd$', '') .. '.' .. suffix,
+    util.join(tests, '_output', relative),
+    util.join(tests, '_site', relative),
+  }
+  for _, candidate in ipairs(candidates) do
+    if util.exists(candidate) then
+      return candidate
+    end
+  end
+  return nil
+end
+
+--- Render a list of documents and judge each result.
+---
+--- Staging is the caller's responsibility, so the smoke layer can generate
+--- documents into an already-staged project rather than staging twice.
+--- @param options table
+--- @param documents table[]
+--- @param descriptors table `test:` descriptors
+--- @param layer string which layer the cases belong to
+--- @param emit function(case)
+function M.execute(options, documents, descriptors, layer, emit)
+  local log_dir = util.join(options.tests, '_results', 'logs')
+  -- Quarto creates the parent of `--log` itself, but a run whose log cannot be
+  -- written loses the promoted-warning check silently, so it is not left to
+  -- undocumented behaviour.
+  pcall(pandoc.system.make_directory, log_dir, true)
+  local defaults = frontmatter.project_defaults(options.tests)
+  local context = { tests = options.tests, log_dir = log_dir }
+
+  for _, document in ipairs(documents) do
+    local settings, warnings = frontmatter.read(document.absolute, descriptors, defaults)
+    local base_id = layer .. '/' .. document.relative:gsub('%.qmd$', '')
+
+    if settings.skip and settings.skip ~= false then
+      emit({
+        id = base_id,
+        layer = layer,
+        status = 'skip',
+        target = { document = document.relative },
+        diagnostics = { errors = {}, warnings = warnings },
+        failure = {
+          stage = 'discover',
+          reason = 'skipped',
+          message = type(settings.skip) == 'string' and settings.skip or 'the document declares `skip`',
+        },
+      })
+      goto continue
+    end
+
+    do
+      local available, inspect_err = M.formats(document.absolute, options.tests)
+      if inspect_err then
+        emit({
+          id = base_id,
+          layer = layer,
+          status = 'fail',
+          target = { document = document.relative },
+          diagnostics = { errors = {}, warnings = warnings },
+          failure = { stage = 'inspect', reason = 'inspect-failed', message = inspect_err },
+        })
+        goto continue
+      end
+
+      local targets = available
+      if settings.formats then
+        targets = {}
+        for _, wanted in ipairs(settings.formats) do
+          if util.contains(available, wanted) then
+            targets[#targets + 1] = wanted
+          else
+            emit({
+              id = base_id .. '/' .. wanted,
+              layer = layer,
+              status = 'fail',
+              target = { document = document.relative, format = wanted },
+              diagnostics = { errors = {}, warnings = warnings },
+              failure = {
+                stage = 'inspect',
+                reason = 'format-not-available',
+                message = string.format('the document declares `%s`, which Quarto does not report for it', wanted),
+              },
+            })
+          end
+        end
+      end
+
+      for _, format in ipairs(targets) do
+        context.settings = settings
+        context.document = document
+        context.layer = layer
+        local case = render_one(context, format)
+        for _, warning in ipairs(warnings) do
+          table.insert(case.diagnostics.warnings, warning)
+        end
+        emit(case)
+      end
+    end
+
+    ::continue::
+  end
+end
+
+--- Run the render layer.
+--- @param options table
+--- @param descriptors table `test:` descriptors
+--- @param emit function(case)
+function M.run(options, descriptors, emit)
+  local documents = M.discover(options.root, options.tests)
+  if #documents == 0 then
+    emit({
+      id = 'render/discover',
+      layer = 'render',
+      status = 'skip',
+      failure = {
+        stage = 'discover',
+        reason = 'no-test-document',
+        message = 'no `tests/*.qmd`, `example.qmd` or `template.qmd` to render',
+      },
+    })
+    return
+  end
+
+  local staged, stage_err = stage.stage(options.root, options.tests)
+  if stage_err then
+    -- A part-copied extension left in the tree would be rendered by any other
+    -- tool that looks at it before the next run cleans up.
+    stage.unstage(options.tests)
+    emit({
+      id = 'render/stage',
+      layer = 'render',
+      status = 'fail',
+      failure = { stage = 'stage', reason = 'staging-failed', message = stage_err },
+    })
+    return
+  end
+  if #staged.names == 0 then
+    emit({
+      id = 'render/stage',
+      layer = 'render',
+      status = 'skip',
+      failure = {
+        stage = 'stage',
+        reason = 'nothing-to-stage',
+        message = 'the repository ships no extension to stage',
+      },
+    })
+    return
+  end
+
+  local missing = stage.missing_project(options.tests)
+  if missing then
+    stage.unstage(options.tests)
+    emit({
+      id = 'render/stage',
+      layer = 'render',
+      status = 'fail',
+      failure = { stage = 'stage', reason = 'no-project-file', message = missing },
+    })
+    return
+  end
+
+  local ok, err = pcall(M.execute, options, documents, descriptors, 'render', emit)
+
+  stage.unstage(options.tests)
+
+  if not ok then
+    emit({
+      id = 'render/harness',
+      layer = 'render',
+      status = 'fail',
+      failure = { stage = 'render', reason = 'harness-error', message = tostring(err) },
+    })
+  end
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/report.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/report.lua
@@ -1,0 +1,195 @@
+--- Extension Test - Result tree and report emission.
+---
+--- JSON is the canonical format because every downstream consumer is bash
+--- and `jq`. TAP 13 is written alongside for humans and for CI systems that
+--- already parse it, from the same tree, so the two can never disagree.
+
+local M = {}
+
+--- Ordered case statuses. A run is `fail` when any case failed, `pass` when
+--- any passed, and `skip` when every case was skipped.
+M.PASS = 'pass'
+M.FAIL = 'fail'
+M.SKIP = 'skip'
+
+--- Create an empty result tree.
+--- @param meta table framework, extension, quarto and environment metadata
+--- @return table
+function M.new(meta)
+  return {
+    version = 1,
+    framework = meta.framework or {},
+    extension = meta.extension or {},
+    quarto = meta.quarto or {},
+    environment = meta.environment or {},
+    tier = meta.tier or 'render',
+    cases = {},
+  }
+end
+
+--- Count the advisories carried by a result tree.
+--- @param results table
+--- @return integer
+function M.warning_count(results)
+  local count = 0
+  for _, case in ipairs(results.cases) do
+    count = count + #((case.diagnostics or {}).warnings or {})
+  end
+  return count
+end
+
+--- Append a case.
+---
+--- `id` is a stable slash path, `<layer>/<kind>/<name>/<format>`, so two runs
+--- can be diffed and the listing can deep-link a single case.
+--- @param results table
+--- @param case table
+function M.add(results, case)
+  assert(case.id, 'a case needs an id')
+  assert(case.layer, 'a case needs a layer')
+  assert(case.status, 'a case needs a status')
+  case.diagnostics = case.diagnostics or { warnings = {}, errors = {} }
+  -- Present and empty in v1 so v2 can fill it without a schema change
+  -- downstream in publish-results.sh, build-index.sh, or the renderer.
+  case.assertions = case.assertions or {}
+  results.cases[#results.cases + 1] = case
+end
+
+--- Roll per-case results up into per-layer and overall summaries.
+--- @param results table
+--- @return table results
+function M.finalise(results)
+  local layers, order = {}, {}
+  local total = { total = 0, pass = 0, fail = 0, skip = 0 }
+
+  for _, case in ipairs(results.cases) do
+    if not layers[case.layer] then
+      layers[case.layer] = { total = 0, pass = 0, fail = 0, skip = 0 }
+      order[#order + 1] = case.layer
+    end
+    local layer = layers[case.layer]
+    layer.total = layer.total + 1
+    layer[case.status] = (layer[case.status] or 0) + 1
+    total.total = total.total + 1
+    total[case.status] = (total[case.status] or 0) + 1
+  end
+
+  for _, name in ipairs(order) do
+    local layer = layers[name]
+    layer.status = (layer.fail > 0 and M.FAIL) or (layer.pass > 0 and M.PASS) or M.SKIP
+  end
+
+  results.layers = layers
+  results.layer_order = order
+  results.summary = total
+  results.status = (total.fail > 0 and M.FAIL) or (total.pass > 0 and M.PASS) or M.SKIP
+  return results
+end
+
+--- Serialise the tree as JSON.
+--- @param results table
+--- @return string
+function M.to_json(results)
+  return pandoc.json.encode(results)
+end
+
+--- A double-quoted YAML scalar, safe for any message.
+--- @param value any
+--- @return string
+function M.yaml_scalar(value)
+  local text = tostring(value or '')
+    :gsub('\\', '\\\\')
+    :gsub('"', '\\"')
+    :gsub('\n', '\\n')
+    :gsub('\r', '')
+  return '"' .. text .. '"'
+end
+
+--- Serialise the tree as TAP 13.
+--- @param results table
+--- @return string
+function M.to_tap(results)
+  local out = { 'TAP version 13', '1..' .. #results.cases }
+  for index, case in ipairs(results.cases) do
+    local line
+    if case.status == M.SKIP then
+      line = string.format('ok %d - %s # SKIP %s', index, case.id,
+        (case.failure and case.failure.reason) or 'skipped')
+    elseif case.status == M.PASS then
+      line = string.format('ok %d - %s', index, case.id)
+    else
+      line = string.format('not ok %d - %s', index, case.id)
+    end
+    out[#out + 1] = line
+    for _, warning in ipairs((case.diagnostics or {}).warnings or {}) do
+      out[#out + 1] = '# warning: ' .. tostring(warning)
+    end
+    if case.status == M.FAIL and case.failure then
+      -- Quoted: a failure message routinely carries a colon, and a bare
+      -- `message: ERROR: ...` is not the YAML a TAP consumer expects.
+      out[#out + 1] = '  ---'
+      out[#out + 1] = '  stage: ' .. M.yaml_scalar(case.failure.stage)
+      out[#out + 1] = '  reason: ' .. M.yaml_scalar(case.failure.reason)
+      if case.failure.message then
+        out[#out + 1] = '  message: ' .. M.yaml_scalar(case.failure.message)
+      end
+      out[#out + 1] = '  ...'
+    end
+  end
+  return table.concat(out, '\n') .. '\n'
+end
+
+--- A short human summary for stderr.
+--- @param results table
+--- @return string
+function M.to_summary(results)
+  local out = {}
+  for _, name in ipairs(results.layer_order or {}) do
+    local layer = results.layers[name]
+    out[#out + 1] = string.format('  %-12s %s  %d passed, %d failed, %d skipped',
+      name, layer.status == M.FAIL and 'FAIL' or (layer.status == M.PASS and 'ok  ' or 'skip'),
+      layer.pass, layer.fail, layer.skip)
+  end
+  for _, case in ipairs(results.cases) do
+    if case.status == M.FAIL then
+      out[#out + 1] = string.format('  FAIL %s\n       %s: %s', case.id,
+        case.failure and case.failure.stage or '?',
+        case.failure and (case.failure.message or case.failure.reason) or '?')
+    end
+  end
+  for _, case in ipairs(results.cases) do
+    for _, warning in ipairs((case.diagnostics or {}).warnings or {}) do
+      out[#out + 1] = string.format('  warn %s\n       %s', case.id, warning)
+    end
+  end
+  local summary = results.summary or {}
+  local warnings = M.warning_count(results)
+  out[#out + 1] = string.format('  %s: %d cases, %d passed, %d failed, %d skipped, %d warnings',
+    string.upper(results.status or '?'), summary.total or 0, summary.pass or 0,
+    summary.fail or 0, summary.skip or 0, warnings)
+  return table.concat(out, '\n') .. '\n'
+end
+
+--- GitHub Actions annotations, one per failure, so failures land on the diff.
+--- @param results table
+--- @return string
+function M.to_annotations(results)
+  local out = {}
+  for _, case in ipairs(results.cases) do
+    if case.status == M.FAIL then
+      local file = (case.target and case.target.document) or ''
+      local message = (case.failure and (case.failure.message or case.failure.reason)) or 'failed'
+      if file ~= '' then
+        out[#out + 1] = string.format('::error file=%s::%s: %s', file, case.id, message)
+      else
+        out[#out + 1] = string.format('::error::%s: %s', case.id, message)
+      end
+    end
+  end
+  if #out == 0 then
+    return ''
+  end
+  return table.concat(out, '\n') .. '\n'
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/stage.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/stage.lua
@@ -1,0 +1,92 @@
+--- Extension Test - Staging the extension under test.
+---
+--- Quarto builds its extension registry while reading `_quarto.yml`, before
+--- any `pre-render` script runs, so an extension copied in from inside a
+--- render is not seen by that render. Staging therefore happens here, before
+--- Quarto is invoked at all.
+---
+--- Staging is a copy, not a symlink. Measured against Quarto 99.9.9: a
+--- symlinked extension inside a real `_extensions/` directory is silently not
+--- resolved, and the render still exits 0 with only a warning. Symlinking the
+--- whole `_extensions/` directory does work, but that shape is unavailable
+--- here because the same directory must also hold the framework.
+
+local util = require('util')
+
+local M = {}
+
+--- The owner directory generated copies are staged under.
+---
+--- `local` matches the convention the documentation sites already use. It
+--- keeps a staged copy from colliding with an extension named after its
+--- owner, and it says on the face of the path that the copy is generated.
+M.STAGE_OWNER = 'local'
+
+--- The project file names Quarto accepts for a directory.
+M.PROJECT_FILES = { '_quarto.yml', '_quarto.yaml' }
+
+--- Why staging cannot be resolved, when the tests directory is not a project.
+---
+--- Quarto resolves an extension from the project the document belongs to.
+--- Without a project file the tests directory is not one, the staged copy is
+--- never read, and every generated document reports a shortcode that is not
+--- found. That reads as a broken extension when the harness is simply not set
+--- up, so it is reported for what it is.
+--- @param tests string tests directory
+--- @return string|nil message
+function M.missing_project(tests)
+  for _, name in ipairs(M.PROJECT_FILES) do
+    if util.exists(util.join(tests, name)) then
+      return nil
+    end
+  end
+  return string.format(
+    'the tests directory has no `%s`, so the staged extension is not resolved; '
+    .. 'add one that declares `project:` with `type: extension-test`',
+    M.PROJECT_FILES[1])
+end
+
+--- Stage every extension a repository ships into the tests project.
+---
+--- The staging directory is removed first. Copying onto an existing directory
+--- nests the new copy inside the old one, which is the failure the
+--- documentation sync scripts document.
+--- @param root string repository root
+--- @param tests string tests directory
+--- @return table staged {names, dir}
+--- @return string|nil error
+function M.stage(root, tests)
+  local source = util.join(root, '_extensions')
+  local target = util.join(tests, '_extensions', M.STAGE_OWNER)
+
+  util.remove_tree(target)
+
+  if not util.is_dir(source) then
+    return { names = {}, dir = target }, nil
+  end
+
+  local names = {}
+  for _, name in ipairs(util.list_dir(source)) do
+    local from = util.join(source, name)
+    if util.is_dir(from) and util.exists(util.join(from, '_extension.yml')) then
+      local ok, err = util.copy_tree(from, util.join(target, name))
+      if not ok then
+        return { names = names, dir = target }, string.format('cannot stage `%s`: %s', name, tostring(err))
+      end
+      names[#names + 1] = name
+    end
+  end
+
+  return { names = names, dir = target }, nil
+end
+
+--- Remove the staging directory.
+---
+--- Only the generated owner directory is touched, never the framework's own
+--- `tests/_extensions/<owner>/` beside it.
+--- @param tests string tests directory
+function M.unstage(tests)
+  util.remove_tree(util.join(tests, '_extensions', M.STAGE_OWNER))
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/util.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/util.lua
@@ -1,0 +1,327 @@
+--- Extension Test - Shared helpers for the test runner.
+---
+--- Every iteration helper here returns keys in a deterministic order. Lua
+--- table order is not stable between runs, and a test report whose findings
+--- reorder on every run cannot be diffed, which is how the reference
+--- conformance sweep this runner grew out of came to hide regressions.
+
+local M = {}
+
+--- Join path segments with the platform separator.
+--- @param ... string
+--- @return string
+function M.join(...)
+  return pandoc.path.join({ ... })
+end
+
+--- Absolute directory holding the running script.
+--- @return string
+function M.script_dir()
+  local self = arg and arg[0]
+  if not self then
+    local info = debug.getinfo(1, 'S')
+    self = info and info.source and info.source:gsub('^@', '')
+  end
+  if not self then
+    return pandoc.system.get_working_directory()
+  end
+  local dir = pandoc.path.directory(self)
+  if pandoc.path.is_absolute(dir) then
+    return dir
+  end
+  return pandoc.path.normalize(M.join(pandoc.system.get_working_directory(), dir))
+end
+
+--- Resolve a path against the working directory.
+---
+--- A relative path is only valid from the directory it was given in, and the
+--- render layer inspects a document from inside the tests directory, so a
+--- relative path there names a file that is not present.
+--- @param path string
+--- @return string
+function M.absolute(path)
+  if pandoc.path.is_absolute(path) then
+    return pandoc.path.normalize(path)
+  end
+  return pandoc.path.normalize(M.join(pandoc.system.get_working_directory(), path))
+end
+
+--- The SHA-256 command available on this platform, if any.
+---
+--- `shasum` is present on macOS, `sha256sum` on most Linux images. The lookup
+--- runs once: it is the same answer for every file in a run.
+--- @return string|nil command prefix, ready for a quoted path
+local sha256_command_cache = false
+function M.sha256_command()
+  if sha256_command_cache ~= false then
+    return sha256_command_cache
+  end
+  for _, candidate in ipairs({ { 'shasum', 'shasum -a 256 ' }, { 'sha256sum', 'sha256sum ' } }) do
+    local code = M.capture('command -v ' .. candidate[1])
+    if code == 0 then
+      sha256_command_cache = candidate[2]
+      return candidate[2]
+    end
+  end
+  sha256_command_cache = nil
+  return nil
+end
+
+--- SHA-256 of a file, as lower-case hexadecimal.
+---
+--- The Pandoc that Quarto ships offers `sha1` and no SHA-256, so this shells
+--- out. A caller must be able to tell three outcomes apart: a digest, no tool
+--- to compute one with, and a path the tool cannot read. Reporting the last
+--- as the second says the machine is at fault when the file is.
+--- @param path string
+--- @return string|nil digest
+--- @return string|nil reason `no-tool` or `unreadable`
+function M.sha256(path)
+  local command = M.sha256_command()
+  if not command then
+    return nil, 'no-tool'
+  end
+  local code, output = M.capture(command .. M.shell_quote(path))
+  if code == 0 then
+    local digest = M.trim(output):match('^(%x+)')
+    if digest then
+      return digest:lower(), nil
+    end
+  end
+  return nil, 'unreadable'
+end
+
+--- Whether a path exists and is readable.
+--- @param path string
+--- @return boolean
+function M.exists(path)
+  local handle = io.open(path, 'r')
+  if handle then
+    handle:close()
+    return true
+  end
+  -- A directory refuses `io.open` on some platforms but lists fine.
+  local ok = pcall(pandoc.system.list_directory, path)
+  return ok
+end
+
+--- Whether a path is a directory.
+--- @param path string
+--- @return boolean
+function M.is_dir(path)
+  local ok = pcall(pandoc.system.list_directory, path)
+  return ok
+end
+
+--- Read a whole file.
+--- @param path string
+--- @return string|nil contents, string|nil error
+function M.read_file(path)
+  local handle, err = io.open(path, 'rb')
+  if not handle then
+    return nil, err or ('cannot read ' .. path)
+  end
+  local contents = handle:read('a')
+  handle:close()
+  return contents, nil
+end
+
+--- Write a whole file, creating parent directories.
+--- @param path string
+--- @param contents string
+--- @return boolean ok, string|nil error
+function M.write_file(path, contents)
+  local dir = pandoc.path.directory(path)
+  if dir and dir ~= '' and dir ~= '.' then
+    pcall(pandoc.system.make_directory, dir, true)
+  end
+  local handle, err = io.open(path, 'wb')
+  if not handle then
+    return false, err or ('cannot write ' .. path)
+  end
+  handle:write(contents)
+  handle:close()
+  return true, nil
+end
+
+--- Directory entries, sorted, without `.` and `..`.
+--- @param path string
+--- @return string[]
+function M.list_dir(path)
+  local ok, entries = pcall(pandoc.system.list_directory, path)
+  if not ok or not entries then
+    return {}
+  end
+  local names = {}
+  for _, name in ipairs(entries) do
+    if name ~= '.' and name ~= '..' then
+      names[#names + 1] = name
+    end
+  end
+  table.sort(names)
+  return names
+end
+
+--- Recursively copy a directory.
+--- @param src string
+--- @param dest string
+--- @return boolean ok, string|nil error
+function M.copy_tree(src, dest)
+  if not M.is_dir(src) then
+    local contents, err = M.read_file(src)
+    if not contents then
+      return false, err
+    end
+    return M.write_file(dest, contents)
+  end
+  local ok, err = pcall(pandoc.system.make_directory, dest, true)
+  if not ok then
+    return false, tostring(err)
+  end
+  for _, name in ipairs(M.list_dir(src)) do
+    local copied, copy_err = M.copy_tree(M.join(src, name), M.join(dest, name))
+    if not copied then
+      return false, copy_err
+    end
+  end
+  return true, nil
+end
+
+--- Remove a directory tree, ignoring a missing path.
+--- @param path string
+function M.remove_tree(path)
+  if not M.exists(path) then
+    return
+  end
+  pcall(pandoc.system.remove_directory, path, true)
+end
+
+--- Table keys in a stable order.
+--- @param map table
+--- @return string[]
+function M.sorted_keys(map)
+  local keys = {}
+  for key in pairs(map or {}) do
+    keys[#keys + 1] = key
+  end
+  table.sort(keys, function(a, b)
+    return tostring(a) < tostring(b)
+  end)
+  return keys
+end
+
+--- Quote a value for a POSIX shell.
+--- @param value string
+--- @return string
+function M.shell_quote(value)
+  return "'" .. tostring(value):gsub("'", "'\\''") .. "'"
+end
+
+--- Run a command, capturing combined output.
+--- Returns the exit code rather than raising, because every failure here is a
+--- test result rather than a harness error.
+--- @param command string
+--- @return integer code, string output
+function M.capture(command)
+  local handle = io.popen(command .. ' 2>&1', 'r')
+  if not handle then
+    return 127, 'cannot spawn: ' .. command
+  end
+  local output = handle:read('a') or ''
+  local ok, kind, code = handle:close()
+  if ok then
+    return 0, output
+  end
+  if kind == 'exit' or kind == 'signal' then
+    return code or 1, output
+  end
+  return 1, output
+end
+
+--- The timeout command available on this platform, if any.
+---
+--- GNU coreutils supplies `timeout`, which Linux runners and the catalogue's
+--- container both have. macOS ships neither unless coreutils is installed,
+--- where it is `gtimeout`. A run without either is still correct, it just
+--- cannot bound a hung render, so the absence is reported rather than fatal.
+--- @return string|nil name
+local timeout_command_cache = false
+function M.timeout_command()
+  if timeout_command_cache ~= false then
+    return timeout_command_cache
+  end
+  for _, name in ipairs({ 'timeout', 'gtimeout' }) do
+    local code = M.capture('command -v ' .. name)
+    if code == 0 then
+      timeout_command_cache = name
+      return name
+    end
+  end
+  timeout_command_cache = nil
+  return nil
+end
+
+--- A command prefix bounding a run to `seconds`, empty when unavailable.
+--- @param seconds number
+--- @return string
+function M.timeout_prefix(seconds)
+  local command = M.timeout_command()
+  if not command then
+    return ''
+  end
+  return string.format('%s %d ', command, math.floor(tonumber(seconds) or 300))
+end
+
+--- Split text into lines, dropping a trailing empty line.
+--- @param text string
+--- @return string[]
+function M.lines(text)
+  local out = {}
+  for line in tostring(text or ''):gmatch('([^\n]*)\n?') do
+    out[#out + 1] = line
+  end
+  if #out > 0 and out[#out] == '' then
+    table.remove(out)
+  end
+  return out
+end
+
+--- Trim surrounding whitespace.
+--- @param value string
+--- @return string
+function M.trim(value)
+  return (tostring(value or ''):gsub('^%s+', ''):gsub('%s+$', ''))
+end
+
+--- A copy of a list of messages in a stable order.
+---
+--- The reference validator walks its descriptor and value maps with `pairs`,
+--- and Lua seeds string hashes per process, so the same input yields the same
+--- findings in a different order on every run. Sorting them here is what makes
+--- a result diffable, and it is done at the point of consumption because the
+--- validator is vendored upstream code.
+--- @param messages string[]
+--- @return string[]
+function M.sorted_messages(messages)
+  local copy = {}
+  for index, message in ipairs(messages or {}) do
+    copy[index] = message
+  end
+  table.sort(copy)
+  return copy
+end
+
+--- Whether an array contains a value.
+--- @param list table
+--- @param needle any
+--- @return boolean
+function M.contains(list, needle)
+  for _, item in ipairs(list or {}) do
+    if item == needle then
+      return true
+    end
+  end
+  return false
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_modules/values.lua
+++ b/tests/_extensions/mcanouil/extension-test/_modules/values.lua
@@ -1,0 +1,305 @@
+--- Extension Test - Deriving a concrete value from a field descriptor.
+---
+--- The governing invariant: every value this module hands back has been
+--- validated against the descriptor it came from. Candidates are tried in
+--- order and the first that validates wins; when none validates the
+--- descriptor is undecidable and the caller skips it.
+---
+--- That one rule is what makes the smoke layer safe to point at schemas this
+--- framework has never seen. A smoke failure is then always the extension's
+--- fault and never the generator's, because the generator provably never
+--- emits a value the extension's own declared contract rejects. It also means
+--- the generator and the validator cannot drift, since they are the same code.
+
+local schema = require('schema')
+
+local M = {}
+
+--- Strings tried when a descriptor constrains a value in a way the type
+--- default does not satisfy, most often a `pattern`.
+---
+--- Reversing a regular expression is unsound, so the generator guesses from a
+--- fixed corpus and lets the validator decide. A descriptor none of these
+--- satisfies is reported as undecidable rather than guessed at.
+--- The empty string is deliberately not a probe. The reference validator
+--- accepts it against a `pattern` it does not match, treating it as an absent
+--- value rather than a failing one, so using it here would let the generator
+--- emit a value that satisfies the contract only by that leniency. A
+--- descriptor nothing else satisfies is reported undecidable instead.
+M.PROBES = {
+  'test', 'a', 'x', '1', '10', 'true', 'false', '#336699', '1px', '1rem',
+  '100%', '1s', '10ms', 'https://example.com', 'test@example.com',
+  '2026-01-01', '2026-01-01T00:00:00Z', 'left', 'center', 'right',
+}
+
+--- Strings a `format` or `completion` hint suggests.
+local HINTED = {
+  uri = 'https://example.com',
+  url = 'https://example.com',
+  email = 'test@example.com',
+  date = '2026-01-01',
+  ['date-time'] = '2026-01-01T00:00:00Z',
+  time = '00:00:00',
+  color = '#336699',
+  colour = '#336699',
+  size = '1rem',
+  directory = 'assets',
+}
+
+--- Whether a value satisfies its own descriptor.
+--- @param value any
+--- @param descriptor table
+--- @return boolean
+function M.validates(value, descriptor)
+  local ok, valid = pcall(schema.validate,
+    { probe = value }, { probe = descriptor }, { unknown = 'ignore' })
+  return ok and valid == true
+end
+
+--- The declared types of a descriptor, always as a list.
+--- @param descriptor table
+--- @return string[]
+local function types_of(descriptor)
+  local declared = descriptor.type
+  if type(declared) == 'table' then
+    return declared
+  end
+  if declared == nil then
+    return {}
+  end
+  return { declared }
+end
+
+--- A number satisfying the descriptor's numeric bounds.
+--- @param descriptor table
+--- @param integral boolean
+--- @return number
+local function derive_number(descriptor, integral)
+  local value = 1
+  if type(descriptor.minimum) == 'number' then
+    value = descriptor.minimum
+  elseif type(descriptor.exclusiveMinimum) == 'number' then
+    value = descriptor.exclusiveMinimum + (integral and 1 or 0.1)
+  end
+  if type(descriptor.multipleOf) == 'number' and descriptor.multipleOf > 0 then
+    local factor = math.ceil(value / descriptor.multipleOf)
+    if factor == 0 then
+      factor = 1
+    end
+    value = factor * descriptor.multipleOf
+  end
+  if type(descriptor.maximum) == 'number' and value > descriptor.maximum then
+    value = descriptor.maximum
+  elseif type(descriptor.exclusiveMaximum) == 'number' and value >= descriptor.exclusiveMaximum then
+    value = descriptor.exclusiveMaximum - (integral and 1 or 0.1)
+  end
+  if integral then
+    value = math.floor(value)
+  end
+  return value
+end
+
+--- A string satisfying the descriptor's length bounds and any hint.
+--- @param descriptor table
+--- @return string
+local function derive_string(descriptor)
+  local value = 'test'
+  local hint = descriptor.format
+  if type(descriptor.completion) == 'table' then
+    hint = descriptor.completion.type or hint
+    if descriptor.completion.type == 'file' then
+      local extensions = descriptor.completion.extensions
+      local suffix = (type(extensions) == 'table' and extensions[1]) or '.txt'
+      value = 'test' .. suffix
+      hint = nil
+    end
+  end
+  if hint and HINTED[hint] then
+    value = HINTED[hint]
+  end
+  local minimum = tonumber(descriptor.minLength)
+  local maximum = tonumber(descriptor.maxLength)
+  if minimum and #value < minimum then
+    value = value .. string.rep('x', minimum - #value)
+  end
+  if maximum and #value > maximum then
+    value = value:sub(1, maximum)
+  end
+  return value
+end
+
+--- Derive a value from a descriptor's declared type.
+--- @param descriptor table
+--- @param name string one declared type
+--- @param depth integer
+--- @return any value, boolean ok
+local function derive_typed(descriptor, name, depth)
+  if depth > 8 then
+    return nil, false
+  end
+  if name == 'string' then
+    return derive_string(descriptor), true
+  elseif name == 'number' then
+    return derive_number(descriptor, false), true
+  elseif name == 'integer' then
+    return derive_number(descriptor, true), true
+  elseif name == 'boolean' then
+    return true, true
+  elseif name == 'content' then
+    return '*test* content', true
+  elseif name == 'null' then
+    return nil, false
+  elseif name == 'array' then
+    local count = math.max(tonumber(descriptor.minItems) or 1, 1)
+    local items = {}
+    if type(descriptor.items) == 'table' then
+      local item, ok = M.derive(descriptor.items, depth + 1)
+      if not ok then
+        return nil, false
+      end
+      for index = 1, count do
+        items[index] = item
+      end
+    else
+      for index = 1, count do
+        items[index] = 'test'
+      end
+    end
+    return items, true
+  elseif name == 'object' then
+    local object = {}
+    if type(descriptor.properties) == 'table' then
+      for _, key in ipairs(schema.key_order(descriptor.properties)) do
+        local child = descriptor.properties[key]
+        if type(child) == 'table' then
+          local value, ok = M.derive(child, depth + 1)
+          if ok then
+            object[key] = value
+          elseif child.required == true then
+            return nil, false
+          end
+        end
+      end
+    elseif type(descriptor.additionalProperties) == 'table' then
+      local value, ok = M.derive(descriptor.additionalProperties, depth + 1)
+      if ok then
+        object.key = value
+      end
+    end
+    return object, true
+  end
+  return nil, false
+end
+
+--- Candidate values for a descriptor, in priority order.
+--- @param descriptor table
+--- @param depth integer
+--- @return table[] list of {value, source}
+local function candidates(descriptor, depth)
+  local list = {}
+  local function add(value, source, present)
+    if present then
+      list[#list + 1] = { value = value, source = source }
+    end
+  end
+
+  -- A `const` is a hard constraint, so nothing may outrank it.
+  add(descriptor.const, 'const', descriptor.const ~= nil)
+  add(descriptor.default, 'default', descriptor.default ~= nil)
+  if type(descriptor.enum) == 'table' and descriptor.enum[1] ~= nil then
+    add(descriptor.enum[1], 'enum', true)
+  end
+  if type(descriptor.examples) == 'table' and descriptor.examples[1] ~= nil then
+    add(descriptor.examples[1], 'example', true)
+  end
+
+  for _, name in ipairs(types_of(descriptor)) do
+    local value, ok = derive_typed(descriptor, name, depth)
+    add(value, 'type:' .. tostring(name), ok)
+  end
+
+  -- Last resort for a constraint the type default does not satisfy. Every
+  -- probe is still validated, so a wrong guess is discarded rather than
+  -- emitted.
+  local declared = types_of(descriptor)
+  local stringish = #declared == 0
+  for _, name in ipairs(declared) do
+    if name == 'string' or name == 'content' then
+      stringish = true
+    end
+  end
+  if stringish then
+    for _, probe in ipairs(M.PROBES) do
+      add(probe, 'probe', true)
+    end
+  end
+
+  return list
+end
+
+--- Derive a value for a descriptor.
+--- @param descriptor table
+--- @param depth integer|nil
+--- @return any value
+--- @return boolean ok false when the descriptor is undecidable
+--- @return string source which candidate won, or the reason it failed
+function M.derive(descriptor, depth)
+  depth = depth or 0
+  if type(descriptor) ~= 'table' then
+    return nil, false, 'not-a-descriptor'
+  end
+
+  for _, candidate in ipairs(candidates(descriptor, depth)) do
+    if M.validates(candidate.value, descriptor) then
+      return candidate.value, true, candidate.source
+    end
+  end
+
+  return nil, false, 'no-value-derivable'
+end
+
+--- Every enum value that validates, for a one-factor-at-a-time sweep.
+---
+--- Capped because a large enum multiplies documents without adding signal,
+--- and the cap is reported rather than silently applied.
+--- @param descriptor table
+--- @param limit integer|nil
+--- @return any[] values, boolean capped
+function M.enum_values(descriptor, limit)
+  limit = limit or 8
+  local values = {}
+  if type(descriptor.enum) ~= 'table' then
+    return values, false
+  end
+  for _, value in ipairs(descriptor.enum) do
+    if #values >= limit then
+      return values, true
+    end
+    if M.validates(value, descriptor) then
+      values[#values + 1] = value
+    end
+  end
+  return values, false
+end
+
+--- Derive values for a whole descriptor map.
+--- @param map table descriptor map
+--- @param filter function|nil predicate on (key, descriptor)
+--- @return table values, table[] undecidable
+function M.derive_map(map, filter)
+  local values, undecidable = {}, {}
+  for _, key in ipairs(schema.key_order(map or {})) do
+    local descriptor = map[key]
+    if type(descriptor) == 'table' and (not filter or filter(key, descriptor)) then
+      local value, ok, source = M.derive(descriptor)
+      if ok then
+        values[key] = value
+      else
+        undecidable[#undecidable + 1] = { key = key, reason = source, pattern = descriptor.pattern }
+      end
+    end
+  end
+  return values, undecidable
+end
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/_schema.yml
+++ b/tests/_extensions/mcanouil/extension-test/_schema.yml
@@ -1,0 +1,14 @@
+# _schema.yml for "extension-test" metadata extension
+# Describes metadata options for IDE tooling and runtime validation.
+
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
+
+# Extension-level metadata options.
+# Configured in _quarto.yml, _metadata.yml, or document front matter:
+#   extensions:
+#     extension-test:
+#       example-option: "value"
+options:
+  example-option:
+    type: string
+    description: "An example option for the extension-test metadata extension."

--- a/tests/_extensions/mcanouil/extension-test/_vendor/quarto-wizard/LICENSE
+++ b/tests/_extensions/mcanouil/extension-test/_vendor/quarto-wizard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/_extensions/mcanouil/extension-test/_vendor/quarto-wizard/schema.lua
+++ b/tests/_extensions/mcanouil/extension-test/_vendor/quarto-wizard/schema.lua
@@ -1,0 +1,2513 @@
+--- MC Schema - Reference validator for Quarto extension schemas (`_schema.yml`)
+--- @module "schema"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 2.0.0
+---
+--- Implements the v2 extension schema vocabulary published at
+--- <https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json>.
+--- The v1 dual-key vocabulary (`min`, `max`, `enum-case-insensitive`,
+--- `element-attributes`, `pattern-exact`) is not accepted.
+---
+--- The module is standalone: it requires no sibling module, and it reaches
+--- `pandoc` and `quarto` only through the `M._env` table, so it can be
+--- exercised outside a Quarto render with stubs in place.
+
+local M = {}
+
+--- Meta-schema this module implements.
+M.SCHEMA_VERSION = 'https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json'
+
+-- ============================================================================
+-- ENVIRONMENT SEAM
+-- ============================================================================
+
+--- Indirection over the two host globals, resolved at call time so a test
+--- harness can install stubs before the first call.
+local _env = {}
+
+--- Render a Pandoc value as plain text.
+--- @param value any Pandoc value
+--- @return string Plain text
+function _env.stringify(value)
+  return pandoc.utils.stringify(value)
+end
+
+--- Report the Pandoc type of a value.
+--- @param value any Pandoc value
+--- @return string Pandoc type name
+function _env.pandoc_type(value)
+  return pandoc.utils.type(value)
+end
+
+--- Emit a warning through the host logger.
+--- @param message string Message to emit
+--- @return nil
+function _env.warn(message)
+  if quarto and quarto.log and quarto.log.warning then
+    quarto.log.warning(message)
+  else
+    io.stderr:write(message .. '\n')
+  end
+end
+
+--- Emit an error through the host logger.
+--- @param message string Message to emit
+--- @return nil
+function _env.report_error(message)
+  if quarto and quarto.log and quarto.log.error then
+    quarto.log.error(message)
+  else
+    io.stderr:write(message .. '\n')
+  end
+end
+
+M._env = _env
+
+-- ============================================================================
+-- CONSTANTS
+-- ============================================================================
+
+--- Maximum nesting depth accepted when converting a parsed schema.
+local MAX_DEPTH = 16
+
+--- Maximum number of Lua patterns one regex may expand into.
+local MAX_PATTERN_BRANCHES = 64
+
+--- Descriptor keywords holding a numeric bound.
+local NUMERIC_KEYWORDS = {
+  'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf',
+  'minLength', 'maxLength', 'minItems', 'maxItems',
+}
+
+--- Every keyword the v2 field descriptor may carry, mapped to whether this
+--- module enforces it. Annotations are carried through untouched for tooling.
+M.KEYWORDS = {
+  type = true,
+  required = true,
+  default = true,
+  const = true,
+  enum = true,
+  enumCaseInsensitive = true,
+  pattern = true,
+  minimum = true,
+  maximum = true,
+  exclusiveMinimum = true,
+  exclusiveMaximum = true,
+  multipleOf = true,
+  minLength = true,
+  maxLength = true,
+  minItems = true,
+  maxItems = true,
+  uniqueItems = true,
+  items = true,
+  properties = true,
+  additionalProperties = true,
+  propertyNames = true,
+  dependentRequired = true,
+  aliases = true,
+  deprecated = true,
+  name = true,
+  description = false,
+  title = false,
+  examples = false,
+  format = false,
+  completion = false,
+  contentEncoding = false,
+  contentMediaType = false,
+}
+
+-- ============================================================================
+-- PRIVATE HELPERS
+-- ============================================================================
+
+--- Report whether a table is a dense array.
+--- @param value any Value to inspect
+--- @return boolean True when the table has only keys 1..n
+local function _is_array(value)
+  if type(value) ~= 'table' then
+    return false
+  end
+  local count = 0
+  for _ in pairs(value) do
+    count = count + 1
+  end
+  return count == #value
+end
+
+--- Read a key from a map, accepting the hyphen and underscore spellings.
+--- Keys are never rewritten, so a schema keeps the names its author wrote.
+--- @param map table|nil Map to read
+--- @param key string|nil Key to read
+--- @return any value The stored value, or nil
+--- @return string|nil found_key The spelling that matched
+local function _lookup(map, key)
+  if type(map) ~= 'table' or type(key) ~= 'string' then
+    return nil, nil
+  end
+  if map[key] ~= nil then
+    return map[key], key
+  end
+  local underscored = (key:gsub('%-', '_'))
+  if underscored ~= key and map[underscored] ~= nil then
+    return map[underscored], underscored
+  end
+  local hyphenated = (key:gsub('_', '-'))
+  if hyphenated ~= key and map[hyphenated] ~= nil then
+    return map[hyphenated], hyphenated
+  end
+  return nil, nil
+end
+
+--- Render any value for an error message, including mixed-type arrays.
+--- Replaces `table.concat`, which throws on a boolean entry.
+--- @param value any Value to render
+--- @return string Readable representation
+local function _format_value(value)
+  local kind = type(value)
+  if kind == 'string' then
+    if value == '' then
+      return '""'
+    end
+    return value
+  elseif kind == 'number' or kind == 'boolean' then
+    return tostring(value)
+  elseif kind == 'nil' then
+    return 'null'
+  elseif kind == 'table' then
+    if _is_array(value) then
+      local parts = {}
+      for index = 1, #value do
+        parts[index] = _format_value(value[index])
+      end
+      return '[' .. table.concat(parts, ', ') .. ']'
+    end
+    return '{object}'
+  end
+  return tostring(value)
+end
+
+--- Render a list of values as a comma-separated string.
+--- @param values table Array of values
+--- @return string Readable list
+local function _format_list(values)
+  local parts = {}
+  for index = 1, #values do
+    parts[index] = _format_value(values[index])
+  end
+  return table.concat(parts, ', ')
+end
+
+--- Normalise a type spec to an array of type names.
+--- @param type_spec string|table|nil Declared type
+--- @return table|nil Array of type names, or nil when no type is declared
+local function _type_names(type_spec)
+  if type_spec == nil then
+    return nil
+  end
+  if type(type_spec) == 'table' then
+    return type_spec
+  end
+  return { type_spec }
+end
+
+--- Render a type spec for an error message.
+--- @param type_spec string|table Declared type
+--- @return string Readable type
+local function _format_type(type_spec)
+  if type(type_spec) == 'table' then
+    return table.concat(type_spec, ' | ')
+  end
+  return tostring(type_spec)
+end
+
+--- Report the type name of a value, distinguishing arrays from objects.
+--- @param value any Value to inspect
+--- @return string Type name
+local function _actual_type(value)
+  local kind = type(value)
+  if kind == 'table' then
+    return _is_array(value) and 'array' or 'object'
+  end
+  if kind == 'nil' then
+    return 'null'
+  end
+  return kind
+end
+
+--- Report whether a value satisfies a single type name.
+--- @param value any Value to check
+--- @param name string Type name
+--- @return boolean True when the value matches
+local function _matches_type(value, name)
+  if name == 'content' then
+    return value ~= nil
+  end
+  if name == 'null' then
+    return value == nil
+  end
+  if name == 'integer' then
+    return type(value) == 'number'
+      and value == value
+      and value ~= math.huge
+      and value ~= -math.huge
+      and value == math.floor(value)
+  end
+  if name == 'number' then
+    return type(value) == 'number'
+  end
+  if name == 'boolean' then
+    return type(value) == 'boolean'
+  end
+  if name == 'string' then
+    return type(value) == 'string'
+  end
+  if name == 'array' then
+    return type(value) == 'table' and _is_array(value)
+  end
+  if name == 'object' then
+    -- An array is not an object. An empty table is both, and Lua cannot tell
+    -- the two apart, so it satisfies either.
+    return type(value) == 'table' and (next(value) == nil or not _is_array(value))
+  end
+  return false
+end
+
+--- Report whether a value satisfies any declared type.
+--- @param value any Value to check
+--- @param type_spec string|table|nil Declared type
+--- @return boolean True when the value matches, or no type is declared
+local function _matches_type_spec(value, type_spec)
+  local names = _type_names(type_spec)
+  if names == nil then
+    return true
+  end
+  for _, name in ipairs(names) do
+    if _matches_type(value, name) then
+      return true
+    end
+  end
+  return false
+end
+
+--- Coerce a string toward a single scalar type.
+--- Pandoc renders every YAML number as a string, so the incoming value and
+--- the schema's own literals both need this before any comparison.
+--- @param value any Value to coerce
+--- @param name string Target type name
+--- @return any coerced Coerced value, or nil
+--- @return boolean ok True when the coercion applied
+local function _coerce_scalar(value, name)
+  if type(value) ~= 'string' then
+    return nil, false
+  end
+  if name == 'number' then
+    local number = tonumber(value)
+    if number then
+      return number, true
+    end
+  elseif name == 'integer' then
+    local number = tonumber(value)
+    if number and number == math.floor(number) then
+      return number, true
+    end
+  elseif name == 'boolean' then
+    local lowered = value:lower()
+    if lowered == 'true' or lowered == 'yes' then
+      return true, true
+    end
+    if lowered == 'false' or lowered == 'no' then
+      return false, true
+    end
+  end
+  return nil, false
+end
+
+--- Coerce a value toward its declared type.
+--- A value already matching one declared type is returned untouched, so
+--- `type: [boolean, string]` keeps the string "fenced" a string.
+--- @param value any Value to coerce
+--- @param type_spec string|table|nil Declared type
+--- @return any Coerced value
+local function _coerce(value, type_spec)
+  local names = _type_names(type_spec)
+  if names == nil or value == nil then
+    return value
+  end
+  for _, name in ipairs(names) do
+    if _matches_type(value, name) then
+      return value
+    end
+  end
+  for _, name in ipairs(names) do
+    local coerced, ok = _coerce_scalar(value, name)
+    if ok then
+      return coerced
+    end
+  end
+  return value
+end
+
+-- ============================================================================
+-- PATTERN COMPILATION
+-- ============================================================================
+
+--- Lua replacements for JS shorthand classes, outside a character class.
+local ESCAPE_OUTSIDE = {
+  d = '%d', D = '%D', w = '[%w_]', W = '[^%w_]', s = '%s', S = '%S',
+}
+
+--- Lua replacements for JS shorthand classes, inside a character class.
+--- `\W` has no in-class form, because the underscore cannot be excluded there.
+local ESCAPE_INSIDE = {
+  d = '%d', D = '%D', w = '%w_', s = '%s', S = '%S',
+}
+
+--- Escapes with a real Lua equivalent. Anything else alphanumeric is refused,
+--- because compiling it to the bare letter would accept the wrong values.
+local CONTROL_ESCAPES = {
+  n = '\n',
+  t = '\t',
+  r = '\r',
+  f = '\f',
+  v = '\v',
+}
+
+--- Characters Lua treats as magic outside a character class.
+local LUA_MAGIC = '^$()%.[]*+-?'
+
+--- Escape one literal character for use in a Lua pattern.
+--- @param char string Single character
+--- @return string Escaped character
+local function _escape_literal(char)
+  if LUA_MAGIC:find(char, 1, true) then
+    return '%' .. char
+  end
+  return char
+end
+
+--- Compile a JS regular expression into a list of equivalent Lua patterns.
+--- Alternation is expanded into one pattern per branch, which is how Lua,
+--- lacking alternation, can honour the commonest JSON Schema idiom.
+--- Anything that cannot be expressed is reported rather than accepted.
+--- @param regex string JS regular expression
+--- @return table|nil branches Array of Lua patterns, or nil on failure
+--- @return string|nil reason Why compilation failed
+local function _compile_pattern(regex)
+  local position = 1
+  local length = #regex
+  local anchor_start = false
+  local anchor_end = false
+  local has_top_level_alternation = false
+  local parse_alternation
+
+  --- Combine a set of prefixes with a set of continuations.
+  local function cross(prefixes, continuations)
+    local out = {}
+    for _, prefix in ipairs(prefixes) do
+      for _, continuation in ipairs(continuations) do
+        if #out >= MAX_PATTERN_BRANCHES then
+          return nil, 'alternation expands past ' .. MAX_PATTERN_BRANCHES .. ' branches'
+        end
+        out[#out + 1] = prefix .. continuation
+      end
+    end
+    return out
+  end
+
+  --- Parse a bracketed character class starting at the current position.
+  local function parse_class()
+    local out = { '[' }
+    position = position + 1
+    if regex:sub(position, position) == '^' then
+      out[#out + 1] = '^'
+      position = position + 1
+    end
+    if regex:sub(position, position) == ']' then
+      out[#out + 1] = '%]'
+      position = position + 1
+    end
+    while position <= length do
+      local char = regex:sub(position, position)
+      if char == ']' then
+        position = position + 1
+        out[#out + 1] = ']'
+        return table.concat(out)
+      elseif char == '\\' then
+        local next_char = regex:sub(position + 1, position + 1)
+        if next_char == '' then
+          return nil, 'trailing backslash'
+        end
+        if next_char == 'W' then
+          return nil, 'unsupported "\\W" inside a character class'
+        end
+        local mapped = ESCAPE_INSIDE[next_char]
+        if mapped then
+          out[#out + 1] = mapped
+        elseif next_char:match('[1-9]') then
+          return nil, 'unsupported backreference "\\' .. next_char .. '"'
+        elseif next_char == '%' then
+          out[#out + 1] = '%%'
+        elseif CONTROL_ESCAPES[next_char] then
+          out[#out + 1] = CONTROL_ESCAPES[next_char]
+        elseif next_char:match('%w') then
+          return nil, 'unsupported escape "\\' .. next_char .. '"'
+        else
+          out[#out + 1] = '%' .. next_char
+        end
+        position = position + 2
+      elseif char == '%' then
+        out[#out + 1] = '%%'
+        position = position + 1
+      else
+        out[#out + 1] = char
+        position = position + 1
+      end
+    end
+    return nil, 'unterminated character class'
+  end
+
+  --- Read a trailing quantifier, rejecting the forms Lua cannot express.
+  local function parse_quantifier()
+    local char = regex:sub(position, position)
+    if char ~= '*' and char ~= '+' and char ~= '?' then
+      return ''
+    end
+    if regex:sub(position + 1, position + 1) == '?' then
+      return nil, 'unsupported non-greedy quantifier "' .. char .. '?"'
+    end
+    position = position + 1
+    return char
+  end
+
+  --- Parse a single atom and return the branches it contributes.
+  local function parse_atom(depth, at_sequence_start)
+    local char = regex:sub(position, position)
+
+    if char == '(' then
+      if regex:sub(position + 1, position + 1) == '?' then
+        local marker = regex:sub(position + 2, position + 2)
+        if marker == '=' or marker == '!' or marker == '<' then
+          return nil, 'unsupported lookahead or lookbehind'
+        end
+        if marker ~= ':' then
+          return nil, 'unsupported group modifier "(?' .. marker .. '"'
+        end
+        position = position + 3
+      else
+        position = position + 1
+      end
+      local branches, reason = parse_alternation(depth + 1)
+      if not branches then
+        return nil, reason
+      end
+      if regex:sub(position, position) ~= ')' then
+        return nil, 'unterminated group'
+      end
+      position = position + 1
+      local quantifier = regex:sub(position, position)
+      if quantifier == '*' or quantifier == '+' or quantifier == '?' then
+        return nil, 'unsupported quantifier applied to a group'
+      end
+      return branches
+    end
+
+    if char == '[' then
+      local class, reason = parse_class()
+      if not class then
+        return nil, reason
+      end
+      local quantifier, quantifier_reason = parse_quantifier()
+      if not quantifier then
+        return nil, quantifier_reason
+      end
+      return { class .. quantifier }
+    end
+
+    if char == '\\' then
+      local next_char = regex:sub(position + 1, position + 1)
+      if next_char == '' then
+        return nil, 'trailing backslash'
+      end
+      if next_char:match('[1-9]') then
+        return nil, 'unsupported backreference "\\' .. next_char .. '"'
+      end
+      position = position + 2
+      local mapped = ESCAPE_OUTSIDE[next_char]
+      local atom
+      if mapped then
+        atom = mapped
+      elseif CONTROL_ESCAPES[next_char] then
+        atom = CONTROL_ESCAPES[next_char]
+      elseif next_char:match('%w') then
+        return nil, 'unsupported escape "\\' .. next_char .. '"'
+      else
+        atom = _escape_literal(next_char)
+      end
+      local quantifier, quantifier_reason = parse_quantifier()
+      if not quantifier then
+        return nil, quantifier_reason
+      end
+      return { atom .. quantifier }
+    end
+
+    if char == '^' then
+      if depth ~= 0 or not at_sequence_start or position ~= 1 then
+        return nil, 'unsupported anchor "^" away from the start of the pattern'
+      end
+      position = position + 1
+      anchor_start = true
+      return { '' }
+    end
+
+    if char == '$' then
+      if depth ~= 0 or position ~= length then
+        return nil, 'unsupported anchor "$" away from the end of the pattern'
+      end
+      position = position + 1
+      anchor_end = true
+      return { '' }
+    end
+
+    if char == '{' then
+      return nil, 'unsupported counted quantifier "{n,m}"'
+    end
+
+    if char == '*' or char == '+' or char == '?' then
+      return nil, 'quantifier "' .. char .. '" with nothing to repeat'
+    end
+
+    if char == '.' then
+      position = position + 1
+      local quantifier, quantifier_reason = parse_quantifier()
+      if not quantifier then
+        return nil, quantifier_reason
+      end
+      return { '.' .. quantifier }
+    end
+
+    position = position + 1
+    local atom = _escape_literal(char)
+    local quantifier, quantifier_reason = parse_quantifier()
+    if not quantifier then
+      return nil, quantifier_reason
+    end
+    return { atom .. quantifier }
+  end
+
+  --- Parse one alternative: a run of atoms up to `|`, `)` or the end.
+  local function parse_sequence(depth)
+    local branches = { '' }
+    local first = true
+    while position <= length do
+      local char = regex:sub(position, position)
+      if char == '|' or char == ')' then
+        break
+      end
+      local atom_branches, reason = parse_atom(depth, first)
+      if not atom_branches then
+        return nil, reason
+      end
+      first = false
+      local crossed, cross_reason = cross(branches, atom_branches)
+      if not crossed then
+        return nil, cross_reason
+      end
+      branches = crossed
+    end
+    return branches
+  end
+
+  parse_alternation = function(depth)
+    local all = {}
+    local iterations = 0
+    while true do
+      iterations = iterations + 1
+      local branches, reason = parse_sequence(depth)
+      if not branches then
+        return nil, reason
+      end
+      for _, branch in ipairs(branches) do
+        if #all >= MAX_PATTERN_BRANCHES then
+          return nil, 'alternation expands past ' .. MAX_PATTERN_BRANCHES .. ' branches'
+        end
+        all[#all + 1] = branch
+      end
+      if regex:sub(position, position) == '|' then
+        position = position + 1
+      else
+        break
+      end
+    end
+    if depth == 0 and iterations > 1 then
+      has_top_level_alternation = true
+    end
+    return all
+  end
+
+  local branches, reason = parse_alternation(0)
+  if not branches then
+    return nil, reason
+  end
+  if position <= length then
+    return nil, 'unbalanced ")" in pattern'
+  end
+
+  -- The anchors are collected for the expression as a whole, so applying them
+  -- to multiple top-level branches would anchor branches the author did not anchor.
+  if has_top_level_alternation and (anchor_start or anchor_end) then
+    return nil, 'unsupported anchor in a top-level alternation'
+  end
+
+  local prefix = anchor_start and '^' or ''
+  local suffix = anchor_end and '$' or ''
+  local out = {}
+  for index, branch in ipairs(branches) do
+    out[index] = prefix .. branch .. suffix
+  end
+  return out
+end
+
+M._compile_pattern = _compile_pattern
+
+--- Report whether a string satisfies any compiled branch.
+--- @param value string Value to test
+--- @param branches table Array of Lua patterns
+--- @return boolean True when a branch matches
+local function _pattern_matches(value, branches)
+  for _, branch in ipairs(branches) do
+    local ok, matched = pcall(string.match, value, branch)
+    if ok and matched ~= nil then
+      return true
+    end
+  end
+  return false
+end
+
+-- ============================================================================
+-- PANDOC VALUE CONVERSION
+-- ============================================================================
+
+--- Convert a Pandoc metadata value to a native Lua value.
+--- Pandoc's Lua objects carry no `t` field, so the kind has to come from
+--- `pandoc.utils.type`; testing `value.t` silently turns every string option
+--- into a list of its inline elements.
+--- @param value any Pandoc metadata value
+--- @return any Native Lua value
+local function _convert_pandoc_value(value)
+  local kind = _env.pandoc_type(value)
+
+  -- A bare key, `null` and `~` all arrive as an empty Pandoc `string`, which
+  -- is how Pandoc collapses YAML null. An explicit `""` arrives as an empty
+  -- `Inlines` instead, so the two are told apart before either is unwrapped.
+  if kind == 'string' and value == '' then
+    return nil
+  end
+
+  if type(value) ~= 'table' then
+    return value
+  end
+
+  if kind == 'Inlines' or kind == 'Blocks' or kind == 'Inline' or kind == 'Block' then
+    return _env.stringify(value)
+  end
+
+  if kind == 'List' then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
+    local result = {}
+    for index = 1, #value do
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
+    end
+    return result
+  end
+
+  if _is_array(value) and #value > 0 then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
+    local result = {}
+    for index = 1, #value do
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
+    end
+    return result
+  end
+
+  local result = {}
+  for key, item in pairs(value) do
+    result[tostring(key)] = _convert_pandoc_value(item)
+  end
+  return result
+end
+
+-- ============================================================================
+-- YAML PARSING
+-- ============================================================================
+
+--- Pandoc parses YAML string scalars as Markdown, which rewrites a schema in
+--- place: `^[a-z]+$` arrives as `+$`, and `^\d+\.?\d*m?s$` arrives as
+--- `^.??s$`. The schema file is therefore parsed here instead.
+---
+--- The subset covers what an extension schema needs: block maps and
+--- sequences, plain and quoted scalars, folded and literal block scalars,
+--- flow sequences and flow maps (including ones spanning several lines), and
+--- `#` comments. Anchors, aliases, tags, multiple documents and complex keys
+--- are not supported and are reported rather than misread.
+---
+--- Every function here reports a failure by returning a message rather than
+--- by calling `error`. Quarto replaces `error` with a logger that returns
+--- instead of unwinding, so a module that trusts `error` to stop execution
+--- carries on with invalid state and fails later somewhere unrelated.
+---
+--- One deliberate deviation from YAML: a block scalar is always stripped of
+--- its trailing newline unless it is chomped with `+`. Schema text is
+--- annotation, and a trailing newline there is noise rather than meaning.
+
+--- Build a parse error message carrying the offending line number.
+--- @param line_number number Line number
+--- @param message string Explanation
+--- @return string Formatted message
+local function _yaml_error(line_number, message)
+  return string.format('line %d: %s', line_number, message)
+end
+
+--- Remove a trailing `#` comment, respecting quoted spans.
+--- @param text string Line content
+--- @return string Content without its comment
+local function _strip_comment(text)
+  local out = {}
+  local quote = nil
+  local index = 1
+  while index <= #text do
+    local char = text:sub(index, index)
+    if quote then
+      out[#out + 1] = char
+      if char == '\\' and quote == '"' then
+        index = index + 1
+        out[#out + 1] = text:sub(index, index)
+      elseif char == quote then
+        quote = nil
+      end
+    elseif char == '"' or char == "'" then
+      quote = char
+      out[#out + 1] = char
+    elseif char == '#' and (index == 1 or text:sub(index - 1, index - 1):match('%s')) then
+      break
+    else
+      out[#out + 1] = char
+    end
+    index = index + 1
+  end
+  return (table.concat(out):gsub('%s+$', ''))
+end
+
+--- Trim leading and trailing whitespace.
+--- @param text string Text to trim
+--- @return string Trimmed text
+local function _trim(text)
+  return (text:gsub('^%s+', ''):gsub('%s+$', ''))
+end
+
+--- Parse a scalar, giving numbers and booleans their real Lua types.
+--- @param text string Scalar text
+--- @param line_number number Line number for errors
+--- @return any value Parsed value, nil for an explicit null
+--- @return string|nil err
+local function _parse_scalar(text, line_number)
+  text = _trim(text)
+
+  if text == '' or text == '~' or text == 'null' or text == 'Null' or text == 'NULL' then
+    return nil, nil
+  end
+
+  local first = text:sub(1, 1)
+
+  if first == '"' then
+    if #text < 2 or text:sub(-1) ~= '"' then
+      return nil, _yaml_error(line_number, 'unterminated double-quoted scalar')
+    end
+    return (text:sub(2, -2):gsub('\\(.)', function(escaped)
+      if escaped == 'n' then return '\n' end
+      if escaped == 't' then return '\t' end
+      if escaped == 'r' then return '\r' end
+      return escaped
+    end)), nil
+  end
+
+  if first == "'" then
+    if #text < 2 or text:sub(-1) ~= "'" then
+      return nil, _yaml_error(line_number, 'unterminated single-quoted scalar')
+    end
+    return (text:sub(2, -2):gsub("''", "'")), nil
+  end
+
+  if first == '&' or first == '*' or first == '!' then
+    return nil, _yaml_error(line_number, 'anchors, aliases and tags are not supported')
+  end
+
+  if text == 'true' or text == 'True' or text == 'TRUE' or text == 'yes' or text == 'Yes' then
+    return true, nil
+  end
+  if text == 'false' or text == 'False' or text == 'FALSE' or text == 'no' or text == 'No' then
+    return false, nil
+  end
+
+  local number = tonumber(text)
+  if number ~= nil and text:match('^[%-+]?[%d%.eE%+%-]+$') then
+    return number, nil
+  end
+
+  return text, nil
+end
+
+--- Split a flow collection body on its top-level commas.
+--- @param body string Text between the brackets
+--- @return table Array of raw item strings
+local function _split_flow(body)
+  local items = {}
+  local depth = 0
+  local quote = nil
+  local start = 1
+  local index = 1
+  while index <= #body do
+    local char = body:sub(index, index)
+    if quote then
+      if char == '\\' and quote == '"' then
+        index = index + 1
+      elseif char == quote then
+        quote = nil
+      end
+    elseif char == '"' or char == "'" then
+      quote = char
+    elseif char == '[' or char == '{' then
+      depth = depth + 1
+    elseif char == ']' or char == '}' then
+      depth = depth - 1
+    elseif char == ',' and depth == 0 then
+      items[#items + 1] = body:sub(start, index - 1)
+      start = index + 1
+    end
+    index = index + 1
+  end
+  local tail = body:sub(start)
+  if tail:match('%S') then
+    items[#items + 1] = tail
+  end
+  return items
+end
+
+--- Strip the quotes from a mapping key.
+--- @param key string Raw key text
+--- @param line_number number Line number for errors
+--- @return string|nil key
+--- @return string|nil err
+local function _unquote_key(key, line_number)
+  key = _trim(key)
+  local first = key:sub(1, 1)
+  if first == '"' or first == "'" then
+    local parsed, err = _parse_scalar(key, line_number)
+    if err then
+      return nil, err
+    end
+    return tostring(parsed), nil
+  end
+  return key, nil
+end
+
+local _parse_flow
+
+--- Parse a value written in flow style, or a plain scalar.
+--- @param text string Value text
+--- @param line_number number Line number for errors
+--- @param depth number|nil Current nesting depth
+--- @return any value
+--- @return string|nil err
+_parse_flow = function(text, line_number, depth)
+  depth = depth or 0
+  if depth > MAX_DEPTH then
+    return nil, _yaml_error(line_number, 'value nests deeper than ' .. MAX_DEPTH .. ' levels')
+  end
+
+  text = _trim(text)
+  local first = text:sub(1, 1)
+
+  if first == '[' then
+    if text:sub(-1) ~= ']' then
+      return nil, _yaml_error(line_number, 'unterminated flow sequence')
+    end
+    local out = {}
+    for index, item in ipairs(_split_flow(text:sub(2, -2))) do
+      local value, err = _parse_flow(item, line_number, depth + 1)
+      if err then
+        return nil, err
+      end
+      out[index] = value
+    end
+    return out, nil
+  end
+
+  if first == '{' then
+    if text:sub(-1) ~= '}' then
+      return nil, _yaml_error(line_number, 'unterminated flow mapping')
+    end
+    local out = {}
+    for _, item in ipairs(_split_flow(text:sub(2, -2))) do
+      local key, rest = item:match('^%s*(.-)%s*:%s*(.*)$')
+      if not key or key == '' then
+        return nil, _yaml_error(line_number, 'expected "key: value" inside a flow mapping')
+      end
+      local name, key_err = _unquote_key(key, line_number)
+      if key_err then
+        return nil, key_err
+      end
+      local value, err = _parse_flow(rest, line_number, depth + 1)
+      if err then
+        return nil, err
+      end
+      out[name] = value
+    end
+    return out, nil
+  end
+
+  return _parse_scalar(text, line_number)
+end
+
+--- Split a mapping line into its key and the rest of the line.
+--- The separator is the first unquoted colon followed by a space or the end
+--- of the line, so a URL value such as `https://...` is not split.
+--- @param text string Line content
+--- @return string|nil key
+--- @return string|nil rest
+local function _split_key(text)
+  local quote = nil
+  local index = 1
+  while index <= #text do
+    local char = text:sub(index, index)
+    if quote then
+      if char == '\\' and quote == '"' then
+        index = index + 1
+      elseif char == quote then
+        quote = nil
+      end
+    elseif char == '"' or char == "'" then
+      quote = char
+    elseif char == ':' then
+      local following = text:sub(index + 1, index + 1)
+      if following == '' or following == ' ' then
+        return text:sub(1, index - 1), _trim(text:sub(index + 2))
+      end
+    end
+    index = index + 1
+  end
+  return nil, nil
+end
+
+--- Break the source into classified lines.
+--- @param source string YAML text
+--- @return table|nil lines Array of {raw, indent, number, blank, comment}
+--- @return string|nil err
+local function _scan_lines(source)
+  local lines = {}
+  local number = 0
+  for raw in (source .. '\n'):gmatch('([^\n]*)\n') do
+    number = number + 1
+    if raw:find('\t') then
+      return nil, _yaml_error(number, 'tabs are not valid YAML indentation')
+    end
+    local indent = #(raw:match('^ *') or '')
+    local body = raw:sub(indent + 1)
+    lines[#lines + 1] = {
+      raw = raw,
+      indent = indent,
+      number = number,
+      blank = body == '',
+      comment = body:sub(1, 1) == '#',
+    }
+  end
+  return lines, nil
+end
+
+--- Advance past blank and comment lines.
+--- @param lines table Scanned lines
+--- @param index number Starting index
+--- @return number Index of the next significant line
+local function _skip_insignificant(lines, index)
+  while index <= #lines and (lines[index].blank or lines[index].comment) do
+    index = index + 1
+  end
+  return index
+end
+
+--- Read the comment-stripped content of a line.
+--- @param line table Scanned line
+--- @return string Content
+local function _content(line)
+  return _strip_comment(line.raw:sub(line.indent + 1))
+end
+
+--- Track bracket depth across one line, ignoring quoted spans.
+--- @param text string Line content
+--- @param depth number Depth carried in
+--- @param quote string|nil Open quote carried in
+--- @return number depth
+--- @return string|nil quote
+local function _scan_flow_depth(text, depth, quote)
+  local index = 1
+  while index <= #text do
+    local char = text:sub(index, index)
+    if quote then
+      if char == '\\' and quote == '"' then
+        index = index + 1
+      elseif char == quote then
+        quote = nil
+      end
+    elseif char == '"' or char == "'" then
+      quote = char
+    elseif char == '[' or char == '{' then
+      depth = depth + 1
+    elseif char == ']' or char == '}' then
+      depth = depth - 1
+    end
+    index = index + 1
+  end
+  return depth, quote
+end
+
+--- Collect a flow collection that may run across several lines.
+--- @param lines table Scanned lines
+--- @param start number Index of the line holding the opening bracket
+--- @param initial string Flow text already read from that line
+--- @param line_number number Line number for errors
+--- @return string|nil text The whole flow collection on one line
+--- @return number next_index Index of the first line after it
+--- @return string|nil err
+local function _gather_flow(lines, start, initial, line_number)
+  local pieces = { initial }
+  local depth, quote = _scan_flow_depth(initial, 0, nil)
+  local index = start
+
+  while depth > 0 do
+    index = index + 1
+    if index > #lines then
+      return nil, index, _yaml_error(line_number, 'unterminated flow collection')
+    end
+    local content = _content(lines[index])
+    pieces[#pieces + 1] = content
+    depth, quote = _scan_flow_depth(content, depth, quote)
+  end
+
+  return table.concat(pieces, ' '), index + 1, nil
+end
+
+--- Read a folded or literal block scalar.
+--- @param lines table Scanned lines
+--- @param start number First candidate line
+--- @param parent_indent number Indentation of the owning key
+--- @param style string Block style, such as '>', '>-' or '|'
+--- @return string text
+--- @return number next_index
+local function _read_block_scalar(lines, start, parent_indent, style)
+  local kind = style:sub(1, 1)
+  local chomp = style:sub(2, 2)
+
+  local collected = {}
+  local block_indent = nil
+  local index = start
+
+  while index <= #lines do
+    local line = lines[index]
+    if line.blank then
+      collected[#collected + 1] = ''
+      index = index + 1
+    elseif line.indent > parent_indent then
+      block_indent = block_indent or line.indent
+      collected[#collected + 1] = line.raw:sub(block_indent + 1)
+      index = index + 1
+    else
+      break
+    end
+  end
+
+  while #collected > 0 and collected[#collected] == '' do
+    table.remove(collected)
+  end
+
+  local text
+  if kind == '>' then
+    local parts = {}
+    local buffer = {}
+    for _, line in ipairs(collected) do
+      if line == '' then
+        if #buffer > 0 then
+          parts[#parts + 1] = table.concat(buffer, ' ')
+          buffer = {}
+        end
+        parts[#parts + 1] = '\n'
+      else
+        buffer[#buffer + 1] = (line:gsub('%s+$', ''))
+      end
+    end
+    if #buffer > 0 then
+      parts[#parts + 1] = table.concat(buffer, ' ')
+    end
+    text = table.concat(parts)
+  else
+    text = table.concat(collected, '\n')
+  end
+
+  if chomp == '+' then
+    text = text .. '\n'
+  end
+
+  return text, index
+end
+
+local _parse_block
+local _parse_sequence
+
+--- The order in which each parsed mapping declared its keys.
+--- Lua tables have no key order, but a schema is authored in a meaningful one,
+--- and a generator that turns a schema into documentation needs it. The order
+--- is kept beside the data rather than inside it, so it cannot be mistaken for
+--- a key of the mapping. Weak keys let a discarded mapping take its order with
+--- it.
+local _key_order = setmetatable({}, { __mode = 'k' })
+
+--- Parse a block mapping at a known indentation.
+--- @return table|nil map
+--- @return number next_index
+--- @return string|nil err
+local function _parse_map(lines, start, indent, depth)
+  local map = {}
+  local order = {}
+  local index = start
+
+  while index <= #lines do
+    local line = lines[index]
+    if line.blank or line.comment then
+      index = index + 1
+    elseif line.indent < indent then
+      break
+    else
+      if line.indent > indent then
+        return nil, index, _yaml_error(line.number, 'unexpected indentation inside a mapping')
+      end
+
+      local content = _content(line)
+      if content == '' then
+        index = index + 1
+      else
+        if content == '---' or content == '...' then
+          return nil, index,
+            _yaml_error(line.number, 'multiple YAML documents are not supported')
+        end
+
+        if content:sub(1, 1) == '-' then
+          return nil, index,
+            _yaml_error(line.number, 'a sequence item cannot appear inside a mapping here')
+        end
+
+        local raw_key, rest = _split_key(content)
+        if raw_key == nil or _trim(raw_key) == '' then
+          return nil, index, _yaml_error(line.number, 'expected "key: value"')
+        end
+
+        local key, key_err = _unquote_key(raw_key, line.number)
+        if key_err then
+          return nil, index, key_err
+        end
+        if map[key] == nil then
+          order[#order + 1] = key
+        end
+        index = index + 1
+
+        -- An explicit indentation indicator (`|2`, `>2-`) is reported rather
+        -- than misread: without this the whole block is stored as the string
+        -- "|2" and its body is then parsed as further mapping lines.
+        if rest:match('^[|>]%d') or rest:match('^[|>][+%-]%d') then
+          return nil, index, _yaml_error(
+            line.number,
+            'a block scalar indentation indicator is not supported: ' .. rest
+          )
+        end
+
+        local block_style = rest:match('^([|>][+%-]?)$')
+        if block_style then
+          local text, next_index = _read_block_scalar(lines, index, indent, block_style)
+          map[key] = text
+          index = next_index
+        elseif rest == '' then
+          local value, next_index, err = _parse_block(lines, index, indent, depth + 1)
+          if err then
+            return nil, next_index, err
+          end
+
+          -- A block sequence may sit at the column of its own key, which
+          -- `_parse_block` declines because its guard wants a deeper line.
+          -- Nothing was consumed in that case, so read the sequence here.
+          if value == nil and next_index == index then
+            local peek = _skip_insignificant(lines, index)
+            if peek <= #lines and lines[peek].indent == indent then
+              local ahead = _content(lines[peek])
+              if ahead == '-' or ahead:sub(1, 2) == '- ' then
+                value, next_index, err = _parse_sequence(lines, peek, indent, depth + 1)
+                if err then
+                  return nil, next_index, err
+                end
+              end
+            end
+          end
+
+          map[key] = value
+          index = next_index
+        elseif rest:sub(1, 1) == '[' or rest:sub(1, 1) == '{' then
+          local text, next_index, err = _gather_flow(lines, index - 1, rest, line.number)
+          if err then
+            return nil, next_index, err
+          end
+          local value, value_err = _parse_flow(text, line.number, depth)
+          if value_err then
+            return nil, next_index, value_err
+          end
+          map[key] = value
+          index = next_index
+        else
+          local value, err = _parse_flow(rest, line.number, depth)
+          if err then
+            return nil, index, err
+          end
+          map[key] = value
+        end
+      end
+    end
+  end
+
+  _key_order[map] = order
+  return map, index, nil
+end
+
+--- Parse a block sequence at a known indentation.
+--- @return table|nil sequence
+--- @return number next_index
+--- @return string|nil err
+_parse_sequence = function(lines, start, indent, depth)
+  local sequence = {}
+  local index = start
+
+  while index <= #lines do
+    local line = lines[index]
+    if line.blank or line.comment then
+      index = index + 1
+    elseif line.indent < indent then
+      break
+    else
+      if line.indent > indent then
+        return nil, index, _yaml_error(line.number, 'unexpected indentation inside a sequence')
+      end
+
+      local content = _content(line)
+      local rest = content:match('^%-%s*(.*)$')
+      if rest == nil then
+        break
+      end
+
+      if rest == '' then
+        local value, next_index, err = _parse_block(lines, index + 1, indent, depth + 1)
+        if err then
+          return nil, next_index, err
+        end
+        -- A Lua array cannot hold an interior nil, so an empty item would be
+        -- dropped and every later item would shift down one index, moving the
+        -- element that `minItems` and an `items` path such as `preload[2]`
+        -- refer to. Report it instead.
+        if value == nil then
+          return nil, index, _yaml_error(line.number, 'an empty sequence item is not supported')
+        end
+        sequence[#sequence + 1] = value
+        index = next_index
+      elseif _split_key(rest) == nil then
+        -- A plain or flow scalar item, such as `- password` or `- [a, b]`.
+        if rest:sub(1, 1) == '[' or rest:sub(1, 1) == '{' then
+          local text, next_index, err = _gather_flow(lines, index, rest, line.number)
+          if err then
+            return nil, next_index, err
+          end
+          local value, value_err = _parse_flow(text, line.number, depth)
+          if value_err then
+            return nil, next_index, value_err
+          end
+          sequence[#sequence + 1] = value
+          index = next_index
+        else
+          local value, err = _parse_flow(rest, line.number, depth)
+          if err then
+            return nil, index, err
+          end
+          sequence[#sequence + 1] = value
+          index = index + 1
+        end
+      else
+        -- The remainder of the dash line is the first line of the item, and it
+        -- sits at the column where that remainder begins.
+        local offset = #content - #rest
+        local synthetic = {
+          raw = string.rep(' ', indent + offset) .. rest,
+          indent = indent + offset,
+          number = line.number,
+          blank = false,
+          comment = false,
+        }
+        local saved = lines[index]
+        lines[index] = synthetic
+        local value, next_index, err = _parse_block(lines, index, indent, depth + 1)
+        lines[index] = saved
+        if err then
+          return nil, next_index, err
+        end
+        sequence[#sequence + 1] = value
+        index = next_index
+      end
+    end
+  end
+
+  return sequence, index, nil
+end
+
+--- Parse whichever block collection begins at `start`.
+--- @param lines table Scanned lines
+--- @param start number Index to start from
+--- @param parent_indent number|nil Indentation that the block must exceed
+--- @param depth number Current nesting depth
+--- @return any value
+--- @return number next_index
+--- @return string|nil err
+_parse_block = function(lines, start, parent_indent, depth)
+  depth = depth or 0
+  local index = _skip_insignificant(lines, start)
+  if index > #lines then
+    return nil, index, nil
+  end
+
+  local line = lines[index]
+  if parent_indent ~= nil and line.indent <= parent_indent then
+    return nil, start, nil
+  end
+
+  if depth > MAX_DEPTH then
+    return nil, index, _yaml_error(line.number, 'schema nests deeper than ' .. MAX_DEPTH .. ' levels')
+  end
+
+  local indent = line.indent
+  local content = _content(line)
+
+  if content:sub(1, 1) == '[' or content:sub(1, 1) == '{' then
+    local text, next_index, err = _gather_flow(lines, index, content, line.number)
+    if err then
+      return nil, next_index, err
+    end
+    local value, value_err = _parse_flow(text, line.number, depth)
+    if value_err then
+      return nil, next_index, value_err
+    end
+    return value, next_index, nil
+  end
+
+  if content == '-' or content:sub(1, 2) == '- ' then
+    return _parse_sequence(lines, index, indent, depth)
+  end
+  return _parse_map(lines, index, indent, depth)
+end
+
+--- Parse YAML text into a native Lua table.
+--- @param source string YAML text
+--- @return table|nil tree
+--- @return string|nil err
+local function _parse_yaml_text(source)
+  local lines, scan_err = _scan_lines(source)
+  if scan_err then
+    return nil, scan_err
+  end
+
+  -- A single leading `---` opens one document, which is valid and common.
+  -- A later one opens a second document, which `_parse_map` reports. Testing
+  -- the raw text instead would also reject a `---` inside a block scalar.
+  local first = _skip_insignificant(lines, 1)
+  if first <= #lines and _content(lines[first]) == '---' then
+    lines[first].blank = true
+  end
+
+  local value, _, err = _parse_block(lines, 1, nil, 0)
+  if err then
+    return nil, err
+  end
+  if value == nil then
+    return {}, nil
+  end
+  if type(value) ~= 'table' or (_is_array(value) and #value > 0) then
+    return nil, 'the file must contain a mapping at its top level'
+  end
+  return value, nil
+end
+
+M._parse_yaml_text = _parse_yaml_text
+
+--- Read and parse a YAML schema file.
+--- @param filename string Path to the schema file
+--- @return table|nil tree
+--- @return string|nil err
+local function _parse_yaml_file(filename)
+  local handle = io.open(filename, 'r')
+  if not handle then
+    return nil, string.format('Could not open schema file: %s', filename)
+  end
+
+  local content = handle:read('*a')
+  handle:close()
+
+  local tree, err = _parse_yaml_text(content)
+  if err then
+    return nil, string.format('Could not parse schema file %s: %s', filename, err)
+  end
+  return tree, nil
+end
+
+
+-- ============================================================================
+-- DESCRIPTOR COMPILATION
+-- ============================================================================
+
+local _compiled_cache = setmetatable({}, { __mode = 'k' })
+
+local _compile
+
+--- Compile a field descriptor: coerce its literals against its own declared
+--- type, compile its patterns, and recurse into nested descriptors.
+--- Returns a new table, so the caller's schema is never mutated.
+--- @param spec table Raw field descriptor
+--- @return table Compiled descriptor
+_compile = function(spec)
+  if type(spec) ~= 'table' then
+    return spec
+  end
+
+  local cached = _compiled_cache[spec]
+  if cached then
+    return cached
+  end
+
+  local out = {}
+  for key, value in pairs(spec) do
+    out[key] = value
+  end
+
+  local type_spec = out.type
+
+  if out.default ~= nil then
+    out.default = _coerce(out.default, type_spec)
+  end
+  if out.const ~= nil then
+    out.const = _coerce(out.const, type_spec)
+  end
+  if type(out.enum) == 'table' then
+    local values = {}
+    for index = 1, #out.enum do
+      values[index] = _coerce(out.enum[index], type_spec)
+    end
+    out.enum = values
+  end
+
+  for _, keyword in ipairs(NUMERIC_KEYWORDS) do
+    if out[keyword] ~= nil then
+      out[keyword] = tonumber(out[keyword]) or out[keyword]
+    end
+  end
+
+  if type(out.required) == 'string' then
+    out.required = out.required:lower() == 'true' or out.required:lower() == 'yes'
+  end
+  if type(out.uniqueItems) == 'string' then
+    out.uniqueItems = out.uniqueItems:lower() == 'true'
+  end
+  if type(out.enumCaseInsensitive) == 'string' then
+    out.enumCaseInsensitive = out.enumCaseInsensitive:lower() == 'true'
+  end
+  if out.additionalProperties == 'false' then
+    out.additionalProperties = false
+  elseif out.additionalProperties == 'true' then
+    out.additionalProperties = true
+  end
+
+  if type(out.pattern) == 'string' then
+    out._pattern, out._pattern_error = _compile_pattern(out.pattern)
+  end
+  if type(out.propertyNames) == 'string' then
+    out._property_names, out._property_names_error = _compile_pattern(out.propertyNames)
+  end
+
+  if type(out.items) == 'table' then
+    out.items = _compile(out.items)
+  end
+  if type(out.properties) == 'table' then
+    local properties = {}
+    for key, value in pairs(out.properties) do
+      properties[key] = _compile(value)
+    end
+    out.properties = properties
+  end
+  if type(out.additionalProperties) == 'table' then
+    out.additionalProperties = _compile(out.additionalProperties)
+  end
+
+  _compiled_cache[spec] = out
+  return out
+end
+
+-- ============================================================================
+-- FINDINGS
+-- ============================================================================
+
+--- Record a finding against a path.
+--- @param context table Validation context
+--- @param severity string 'error' or 'warning'
+--- @param path string Dotted path of the offending value
+--- @param keyword string Keyword that produced the finding
+--- @param message string Human-readable explanation
+--- @return nil
+local function _report(context, severity, path, keyword, message)
+  table.insert(context.findings, {
+    path = path,
+    keyword = keyword,
+    message = message,
+    severity = severity,
+  })
+end
+
+--- Split findings into the string arrays the public API returns.
+--- @param findings table Array of findings
+--- @return table errors Array of error strings
+--- @return table warnings Array of warning strings
+local function _split_findings(findings)
+  local errors = {}
+  local warnings = {}
+  for _, finding in ipairs(findings) do
+    local line = finding.path and (finding.path .. ': ' .. finding.message) or finding.message
+    if finding.severity == 'warning' then
+      table.insert(warnings, line)
+    else
+      table.insert(errors, line)
+    end
+  end
+  return errors, warnings
+end
+
+-- ============================================================================
+-- KEYWORD CHECKS
+-- ============================================================================
+
+local _validate_value
+local _validate_map
+
+--- Check `enum`, honouring `enumCaseInsensitive`.
+local function _check_enum(value, spec, path, context)
+  if type(spec.enum) ~= 'table' then
+    return
+  end
+  local case_insensitive = spec.enumCaseInsensitive == true
+  for _, allowed in ipairs(spec.enum) do
+    if value == allowed then
+      return
+    end
+    if case_insensitive and type(value) == 'string' and type(allowed) == 'string'
+      and value:lower() == allowed:lower() then
+      return
+    end
+  end
+  _report(context, 'error', path, 'enum', string.format(
+    'must be one of: %s, got %s.', _format_list(spec.enum), _format_value(value)
+  ))
+end
+
+--- Check `pattern`, reporting a pattern the module cannot compile.
+local function _check_pattern(value, spec, path, context)
+  if spec.pattern == nil or type(value) ~= 'string' then
+    return
+  end
+  if spec._pattern == nil then
+    _report(context, 'error', path, 'pattern', string.format(
+      'schema declares a pattern this validator cannot compile (%s): %s.',
+      spec._pattern_error or 'unsupported construct', spec.pattern
+    ))
+    return
+  end
+  if not _pattern_matches(value, spec._pattern) then
+    _report(context, 'error', path, 'pattern', string.format(
+      'does not match required pattern: %s.', spec.pattern
+    ))
+  end
+end
+
+--- Check the numeric bounds.
+local function _check_numeric(value, spec, path, context)
+  if type(value) ~= 'number' then
+    return
+  end
+  if type(spec.minimum) == 'number' and value < spec.minimum then
+    _report(context, 'error', path, 'minimum', string.format(
+      'must be at least %s, got %s.', _format_value(spec.minimum), _format_value(value)
+    ))
+  end
+  if type(spec.maximum) == 'number' and value > spec.maximum then
+    _report(context, 'error', path, 'maximum', string.format(
+      'must be at most %s, got %s.', _format_value(spec.maximum), _format_value(value)
+    ))
+  end
+  if type(spec.exclusiveMinimum) == 'number' and value <= spec.exclusiveMinimum then
+    _report(context, 'error', path, 'exclusiveMinimum', string.format(
+      'must be greater than %s, got %s.', _format_value(spec.exclusiveMinimum), _format_value(value)
+    ))
+  end
+  if type(spec.exclusiveMaximum) == 'number' and value >= spec.exclusiveMaximum then
+    _report(context, 'error', path, 'exclusiveMaximum', string.format(
+      'must be less than %s, got %s.', _format_value(spec.exclusiveMaximum), _format_value(value)
+    ))
+  end
+  if type(spec.multipleOf) == 'number' and spec.multipleOf ~= 0 then
+    local quotient = value / spec.multipleOf
+    if quotient ~= math.floor(quotient) then
+      _report(context, 'error', path, 'multipleOf', string.format(
+        'must be a multiple of %s, got %s.', _format_value(spec.multipleOf), _format_value(value)
+      ))
+    end
+  end
+end
+
+--- Check string length.
+local function _check_string_length(value, spec, path, context)
+  if type(value) ~= 'string' then
+    return
+  end
+  -- Count characters rather than bytes, so a multi-byte glyph counts as one.
+  local length = utf8 and utf8.len(value) or nil
+  if length == nil then
+    length = #value
+  end
+  if type(spec.minLength) == 'number' and length < spec.minLength then
+    _report(context, 'error', path, 'minLength', string.format(
+      'must be at least %d characters, got %d.', spec.minLength, length
+    ))
+  end
+  if type(spec.maxLength) == 'number' and length > spec.maxLength then
+    _report(context, 'error', path, 'maxLength', string.format(
+      'must be at most %d characters, got %d.', spec.maxLength, length
+    ))
+  end
+end
+
+--- Check array length and uniqueness.
+local function _check_array(value, spec, path, context)
+  if type(value) ~= 'table' then
+    return
+  end
+  local length = #value
+  if type(spec.minItems) == 'number' and length < spec.minItems then
+    _report(context, 'error', path, 'minItems', string.format(
+      'must have at least %d items, got %d.', spec.minItems, length
+    ))
+  end
+  if type(spec.maxItems) == 'number' and length > spec.maxItems then
+    _report(context, 'error', path, 'maxItems', string.format(
+      'must have at most %d items, got %d.', spec.maxItems, length
+    ))
+  end
+  if spec.uniqueItems == true then
+    local seen = {}
+    for index = 1, length do
+      local element = value[index]
+      local rendered = _format_value(element)
+      -- The key carries the type so 1 and "1" are different items. A string
+      -- keys on its own text rather than on the rendering, because
+      -- `_format_value` renders an empty string as `""`, which would make it
+      -- collide with the two-character string `""`. The message carries only
+      -- the rendering, because the key is not the author's text.
+      local raw = type(element) == 'string' and element or rendered
+      local key = type(element) .. '\0' .. raw
+      if seen[key] then
+        _report(context, 'error', path, 'uniqueItems', string.format(
+          'must not repeat items, but %s appears more than once.', rendered
+        ))
+        break
+      end
+      seen[key] = true
+    end
+  end
+end
+
+--- Validate array elements against `items`.
+local function _check_items(value, spec, path, context)
+  if type(spec.items) ~= 'table' or type(value) ~= 'table' then
+    return
+  end
+  for index = 1, #value do
+    local element = _coerce(value[index], spec.items.type)
+    value[index] = element
+    if element ~= nil then
+      _validate_value(element, spec.items, string.format('%s[%d]', path, index), context)
+    end
+  end
+end
+
+--- Validate object members against `properties` and its companions.
+local function _check_object(value, spec, path, context)
+  if type(value) ~= 'table' then
+    return
+  end
+
+  if spec._property_names ~= nil or spec._property_names_error ~= nil then
+    if spec._property_names == nil then
+      _report(context, 'error', path, 'propertyNames', string.format(
+        'schema declares a propertyNames pattern this validator cannot compile (%s): %s.',
+        spec._property_names_error or 'unsupported construct', spec.propertyNames
+      ))
+    else
+      for key in pairs(value) do
+        if type(key) == 'string' and not _pattern_matches(key, spec._property_names) then
+          _report(context, 'error', path .. '.' .. key, 'propertyNames', string.format(
+            'key does not match required pattern: %s.', spec.propertyNames
+          ))
+        end
+      end
+    end
+  end
+
+  local defaulted = {}
+
+  if type(spec.properties) == 'table' then
+    local sub, filled = _validate_map(value, spec.properties, path, context, {
+      unknown = spec.additionalProperties == false and 'error' or 'ignore',
+      additional = type(spec.additionalProperties) == 'table' and spec.additionalProperties or nil,
+    })
+
+    -- `_validate_map` builds a new table, so its defaults, coercion and alias
+    -- resolution have to be written back into the value the parent holds.
+    -- Without this a nested `properties` contributes nothing to `merged`.
+    local stale = {}
+    for key in pairs(value) do
+      if sub[key] == nil then
+        stale[#stale + 1] = key
+      end
+    end
+    for _, key in ipairs(stale) do
+      value[key] = nil
+    end
+    for key, member in pairs(sub) do
+      value[key] = member
+    end
+    defaulted = filled
+  elseif type(spec.additionalProperties) == 'table' then
+    for key, member in pairs(value) do
+      local coerced = _coerce(member, spec.additionalProperties.type)
+      value[key] = coerced
+      if coerced ~= nil then
+        _validate_value(coerced, spec.additionalProperties, path .. '.' .. tostring(key), context)
+      end
+    end
+  end
+
+  -- Runs after the properties block, which writes the resolved members back
+  -- into `value`. Before that, a dependent supplied under an alias is not yet
+  -- there to be found. A `default` is an annotation and does not change the
+  -- instance, so a key that only holds one neither triggers a requirement nor
+  -- satisfies it.
+  if type(spec.dependentRequired) == 'table' then
+    for key, dependents in pairs(spec.dependentRequired) do
+      local trigger, trigger_key = _lookup(value, key)
+      if trigger ~= nil and not defaulted[trigger_key] and type(dependents) == 'table' then
+        for _, dependent in ipairs(dependents) do
+          local supplied, dependent_key = _lookup(value, dependent)
+          if supplied == nil or defaulted[dependent_key] then
+            _report(context, 'error', path, 'dependentRequired', string.format(
+              'requires "%s" when "%s" is present.', dependent, key
+            ))
+          end
+        end
+      end
+    end
+  end
+end
+
+--- Run every keyword check against one value.
+--- A failed type check short-circuits, so one mistake yields one message.
+--- @param value any Value to validate
+--- @param spec table Compiled descriptor
+--- @param path string Dotted path of the value
+--- @param context table Validation context
+--- @return nil
+_validate_value = function(value, spec, path, context)
+  local names = _type_names(spec.type)
+
+  if names then
+    for _, name in ipairs(names) do
+      if name == 'content' then
+        return
+      end
+    end
+  end
+
+  if not _matches_type_spec(value, spec.type) then
+    _report(context, 'error', path, 'type', string.format(
+      'must be of type "%s", got "%s".', _format_type(spec.type), _actual_type(value)
+    ))
+    return
+  end
+
+  if spec.const ~= nil and value ~= spec.const then
+    _report(context, 'error', path, 'const', string.format(
+      'must be %s, got %s.', _format_value(spec.const), _format_value(value)
+    ))
+  end
+
+  _check_enum(value, spec, path, context)
+  _check_pattern(value, spec, path, context)
+  _check_numeric(value, spec, path, context)
+  _check_string_length(value, spec, path, context)
+  _check_array(value, spec, path, context)
+  _check_items(value, spec, path, context)
+  _check_object(value, spec, path, context)
+end
+
+-- ============================================================================
+-- MAP VALIDATION
+-- ============================================================================
+
+--- Build the deprecation warning for a descriptor, and forward its value.
+--- @param field string Field name
+--- @param spec table Compiled descriptor
+--- @param value any Current value
+--- @param merged table Working values
+--- @return string message Warning text
+--- @return boolean cleared True when the deprecated key was removed
+local function _apply_deprecation(field, spec, value, merged)
+  local deprecated = spec.deprecated
+
+  if type(deprecated) == 'string' then
+    return string.format('option "%s" is deprecated. %s', field, deprecated), false
+  end
+
+  if type(deprecated) ~= 'table' then
+    return string.format('option "%s" is deprecated.', field), false
+  end
+
+  local message
+  if deprecated.since then
+    message = string.format('option "%s" is deprecated since %s.', field, deprecated.since)
+  else
+    message = string.format('option "%s" is deprecated.', field)
+  end
+  if deprecated.message then
+    message = message .. ' ' .. deprecated.message
+  end
+
+  -- A v1 schema writes `replace-with`, which this vocabulary does not accept.
+  -- Say so, rather than dropping the forwarding without a word.
+  local unrecognised = {}
+  for key in pairs(deprecated) do
+    if key ~= 'since' and key ~= 'message' and key ~= 'replaceWith' then
+      unrecognised[#unrecognised + 1] = key
+    end
+  end
+  if #unrecognised > 0 then
+    table.sort(unrecognised)
+    message = message .. string.format(
+      ' The deprecation declares %s, which this vocabulary does not accept; use "replaceWith".',
+      table.concat(unrecognised, ', ')
+    )
+  end
+
+  local cleared = false
+  if deprecated.replaceWith then
+    local replacement = deprecated.replaceWith
+    message = message .. string.format(' Use "%s" instead.', replacement)
+    if _lookup(merged, replacement) == nil then
+      merged[replacement] = value
+    end
+    merged[field] = nil
+    cleared = true
+  end
+
+  return message, cleared
+end
+
+--- Record that a descriptor accepts a spelling, and report a contested one.
+---
+--- Two descriptors can name the same spelling, when one declares as an alias
+--- what another declares as its own name, or when two of them declare the same
+--- alias. `pairs` yields descriptors in no particular order, so which field a
+--- contested spelling resolves to is not decidable from the schema. It is
+--- reported rather than resolved in silence, because the schema is what is
+--- wrong and only its author can settle it.
+---
+--- @param sources table Map of spelling to declared name
+--- @param spelling string The spelling being declared
+--- @param field string The declared name that accepts it
+--- @param base_path string|nil Path prefix for findings
+--- @param context table Validation context
+local function _declare_spelling(sources, spelling, field, base_path, context)
+  -- The owner is read through `_lookup`, like every other name comparison in
+  -- this module, so a contest between the hyphen and the underscore spelling
+  -- of one name is found as well. Those sit under different keys but reach the
+  -- same document key at merge time, so they contest just as directly.
+  local owner = _lookup(sources, spelling)
+  if owner ~= nil and owner ~= field then
+    _report(context, 'warning', base_path and (base_path .. '.' .. spelling) or spelling,
+      'aliases', string.format(
+        'is declared by both "%s" and "%s"; which one accepts it is not defined.',
+        owner, field))
+  end
+  -- Stored under the literal spelling either way. The map is also the set of
+  -- keys a descriptor claimed, and a contested spelling is still claimed: the
+  -- schema is ambiguous, which the warning says, and treating the key as
+  -- undeclared on top of that would report it as unknown as well.
+  sources[spelling] = sources[spelling] or field
+end
+
+
+--- Validate a map of values against a map of field descriptors.
+--- @param values table Values to validate
+--- @param descriptors table Field descriptor map
+--- @param base_path string|nil Path prefix for findings
+--- @param context table Validation context
+--- @param options table|nil {unknown = 'warn'|'error'|'ignore', additional = descriptor}
+--- @return table merged Values with aliases, coercion and defaults applied
+--- @return table defaulted Set of field names whose value came from `default`
+--- @return table sources Map of every spelling the schema accepts to the
+---   declared name it resolves to. A reader that has to answer a question
+---   about a name the caller wrote asks this rather than walking the
+---   descriptors again, because the merge has already decided the answer.
+---   It doubles as the set of keys a descriptor claimed, which is what the
+---   unknown key pass below reads.
+_validate_map = function(values, descriptors, base_path, context, options)
+  options = options or {}
+  local unknown_policy = options.unknown or 'ignore'
+
+  local merged = {}
+  for key, value in pairs(values) do
+    merged[key] = value
+  end
+
+  local defaulted = {}
+  local sources = {}
+  local fields = {}
+
+  -- Three passes, because `pairs` yields descriptors in no particular order.
+  -- Aliases must land before deprecation reads a value, and a `replaceWith`
+  -- target must be populated before its own descriptor is validated.
+  for field, raw_spec in pairs(descriptors) do
+    local spec = _compile(raw_spec)
+    fields[#fields + 1] = {
+      name = field,
+      spec = spec,
+      path = base_path and (base_path .. '.' .. field) or field,
+    }
+    -- Two writes with different weight. Declaring a spelling fills an empty
+    -- slot only, while claiming the value under one overwrites whatever was
+    -- there. The value lands under whichever descriptor claimed it, so the
+    -- claim is what the map has to follow: a declaration that outranked it
+    -- would send a reader to a field the merge has already emptied.
+    _declare_spelling(sources, field, field, base_path, context)
+
+    -- A value found under an alias, or under the other spelling, moves to the
+    -- name the schema declares. The key it came from is removed, so `merged`
+    -- never carries the same value twice, once coerced and once raw.
+    -- The declared name is read first, so it wins over any alias.
+    local supplied_key
+    local found, found_key = _lookup(merged, field)
+    if found ~= nil then
+      merged[field] = found
+      sources[found_key] = field
+      supplied_key = found_key
+      if found_key ~= field then
+        merged[found_key] = nil
+      end
+    end
+
+    if type(spec.aliases) == 'table' then
+      for _, alias in ipairs(spec.aliases) do
+        _declare_spelling(sources, alias, field, base_path, context)
+        local aliased, alias_key = _lookup(merged, alias)
+        if aliased ~= nil then
+          sources[alias_key] = field
+          if merged[field] == nil then
+            merged[field] = aliased
+            supplied_key = alias_key
+          elseif alias_key ~= field then
+            -- Two spellings were supplied. The first one read wins, and the
+            -- other is reported rather than left behind unvalidated. Both
+            -- names come from the document, never from the schema.
+            _report(context, 'warning',
+              base_path and (base_path .. '.' .. field) or field,
+              'aliases',
+              string.format('was given as both "%s" and "%s"; "%s" was used.',
+                supplied_key, alias_key, supplied_key))
+          end
+          if alias_key ~= field then
+            merged[alias_key] = nil
+          end
+        end
+      end
+    end
+  end
+
+  for _, entry in ipairs(fields) do
+    local value = merged[entry.name]
+    if entry.spec.deprecated and value ~= nil then
+      local message, cleared = _apply_deprecation(entry.name, entry.spec, value, merged)
+      _report(context, 'warning', entry.path, 'deprecated', message)
+      entry.cleared = cleared
+    end
+  end
+
+  for _, entry in ipairs(fields) do
+    local field, spec, path = entry.name, entry.spec, entry.path
+    local value
+
+    if entry.cleared then
+      value = nil
+    else
+      value = _coerce(merged[field], spec.type)
+      merged[field] = value
+
+      if value == nil and spec.default ~= nil then
+        value = spec.default
+        merged[field] = value
+        defaulted[field] = true
+      end
+    end
+
+    -- An empty string is a value the author wrote. Only a missing key is
+    -- absent, so `minLength`, `const` and `enum` can be tested against ''.
+    if spec.required == true and value == nil then
+      _report(context, 'error', path, 'required', 'is required but was not provided.')
+    elseif value ~= nil then
+      _validate_value(value, spec, path, context)
+    end
+  end
+
+  if unknown_policy ~= 'ignore' or options.additional then
+    for key, value in pairs(values) do
+      if sources[key] == nil then
+        local path = base_path and (base_path .. '.' .. tostring(key)) or tostring(key)
+        if options.additional then
+          local coerced = _coerce(value, options.additional.type)
+          merged[key] = coerced
+          if coerced ~= nil then
+            _validate_value(coerced, options.additional, path, context)
+          end
+        elseif unknown_policy == 'error' then
+          _report(context, 'error', path, 'additionalProperties', 'is not a recognised key.')
+        else
+          _report(context, 'warning', path, 'additionalProperties', 'is not a recognised key and was ignored.')
+        end
+      end
+    end
+  end
+
+  return merged, defaulted, sources
+end
+
+--- Start a validation run.
+--- @return table Fresh validation context
+local function _new_context()
+  return { findings = {} }
+end
+
+--- Close a validation run and shape the public return values.
+--- @param context table Validation context
+--- @param merged table Merged values
+--- @return boolean valid
+--- @return table errors
+--- @return table warnings
+--- @return table merged
+--- @return table findings
+local function _finish(context, merged)
+  local errors, warnings = _split_findings(context.findings)
+  return #errors == 0, errors, warnings, merged, context.findings
+end
+
+-- ============================================================================
+-- PUBLIC API
+-- ============================================================================
+
+--- Load and parse a schema file.
+--- Sections absent from the file default to an empty table.
+---
+--- A failure is returned, not raised. Quarto replaces `error` with a logger
+--- that returns instead of unwinding, so raising here would let a caller
+--- carry on with a nil schema and fail later somewhere unrelated.
+---
+--- @param filename string|nil Path to the schema file (defaults to '_schema.yml')
+--- @return table|nil schema Schema with {['$schema'], options, shortcodes, formats, projects, attributes, classes}
+--- @return string|nil err Why the schema could not be read
+--- @usage local schema, err = M.load_schema('_schema.yml')
+function M.load_schema(filename)
+  local raw, err = _parse_yaml_file(filename or '_schema.yml')
+  if err then
+    return nil, err
+  end
+
+  return {
+    ['$schema'] = raw['$schema'],
+    options = raw.options or {},
+    shortcodes = raw.shortcodes or {},
+    formats = raw.formats or {},
+    projects = raw.projects or {},
+    attributes = raw.attributes or {},
+    classes = raw.classes or {},
+  }, nil
+end
+
+--- List the keys of a parsed mapping in the order the schema declared them.
+--- A schema is authored in a meaningful order, and a generator that turns one
+--- into documentation needs that order rather than an arbitrary one.
+--- Falls back to sorted keys for a table this module did not parse.
+--- @param map table A mapping from a loaded schema
+--- @return table Array of keys
+--- @usage for _, name in ipairs(schema.key_order(loaded.options)) do
+function M.key_order(map)
+  if type(map) ~= 'table' then
+    return {}
+  end
+
+  local order = _key_order[map]
+  if order ~= nil then
+    local copy = {}
+    for index, key in ipairs(order) do
+      copy[index] = key
+    end
+    return copy
+  end
+
+  local keys = {}
+  for key in pairs(map) do
+    keys[#keys + 1] = key
+  end
+  table.sort(keys)
+  return keys
+end
+
+--- Validate a map of values against a map of field descriptors.
+--- @param values table Values to validate
+--- @param descriptors table Field descriptor map
+--- @param options table|nil {unknown = 'warn'|'error'|'ignore'}
+--- @return boolean valid True when no error was reported
+--- @return table errors Array of error strings
+--- @return table warnings Array of warning strings
+--- @return table merged Values with aliases, coercion and defaults applied
+--- @return table findings Array of structured findings
+--- @usage local valid, errors, warnings, merged = M.validate(options, schema.options)
+function M.validate(values, descriptors, options)
+  options = options or {}
+  local context = _new_context()
+  local merged = _validate_map(values or {}, descriptors or {}, nil, context, {
+    unknown = options.unknown or 'warn',
+  })
+  return _finish(context, merged)
+end
+
+--- Validate positional shortcode arguments against an argument descriptor array.
+--- Each descriptor should carry a `name`; the merged table is keyed by name.
+--- @param args table Array of positional argument values
+--- @param argument_specs table Array of argument descriptors
+--- @param options table|nil {unknown = 'warn'|'ignore'}
+--- @return boolean valid
+--- @return table errors
+--- @return table warnings
+--- @return table merged Map keyed by argument name
+--- @return table findings
+--- @usage local valid, errors, warnings, merged = M.validate_arguments(args, specs)
+function M.validate_arguments(args, argument_specs, options)
+  options = options or {}
+  args = args or {}
+  argument_specs = argument_specs or {}
+
+  local context = _new_context()
+  local merged = {}
+
+  for index, raw_spec in ipairs(argument_specs) do
+    local spec = _compile(raw_spec)
+    local name = spec.name or tostring(index)
+    local path = string.format('argument %d ("%s")', index, name)
+
+    local value = _coerce(args[index], spec.type)
+    if value == nil and spec.default ~= nil then
+      value = spec.default
+    end
+    merged[name] = value
+
+    if spec.required == true and value == nil then
+      _report(context, 'error', path, 'required', 'is required but was not provided.')
+    elseif value ~= nil then
+      _validate_value(value, spec, path, context)
+    end
+  end
+
+  if (options.unknown or 'warn') ~= 'ignore' and #args > #argument_specs then
+    _report(context, 'warning', nil, 'arguments', string.format(
+      'Received %d arguments but only %d are defined. The extra arguments were ignored.',
+      #args, #argument_specs
+    ))
+  end
+
+  return _finish(context, merged)
+end
+
+--- Validate one shortcode call against its schema entry.
+--- Covers the positional `arguments`, the named `attributes`, and the
+--- parent-level `required` array of attribute names.
+--- @param name string Shortcode name, used as the path prefix
+--- @param args table Array of positional argument values
+--- @param kwargs table Map of named attribute values
+--- @param entry table Shortcode entry from `schema.shortcodes[name]`
+--- @param options table|nil {unknown = 'warn'|'error'|'ignore'}
+--- @return boolean valid
+--- @return table errors
+--- @return table warnings
+--- @return table merged {arguments = ..., attributes = ...}
+--- @return table findings
+--- @usage local valid, errors, warnings, merged = M.validate_shortcode('iconify', args, kwargs, schema.shortcodes.iconify)
+function M.validate_shortcode(name, args, kwargs, entry, options)
+  options = options or {}
+  entry = entry or {}
+
+  local context = _new_context()
+  local merged = { arguments = {}, attributes = {} }
+
+  if type(entry.arguments) == 'table' then
+    local _, errors, warnings, arguments = M.validate_arguments(args or {}, entry.arguments, options)
+    merged.arguments = arguments
+    for _, message in ipairs(errors) do
+      _report(context, 'error', nil, 'arguments', name .. ' ' .. message)
+    end
+    for _, message in ipairs(warnings) do
+      _report(context, 'warning', nil, 'arguments', name .. ' ' .. message)
+    end
+  end
+
+  local declared = type(entry.attributes) == 'table'
+  local spellings
+  if declared then
+    local attributes, _, resolved = _validate_map(kwargs or {}, entry.attributes, name, context, {
+      unknown = options.unknown or 'warn',
+    })
+    merged.attributes = attributes
+    spellings = resolved
+  end
+
+  if type(entry.required) == 'table' then
+    -- `merged.attributes` is filled only when the entry declares `attributes`,
+    -- and it is authoritative when it is: it keeps every unclaimed key and it
+    -- drops a key that a deprecation cleared. The vocabulary allows `required`
+    -- on its own, so fall back to what the caller supplied only when the
+    -- entry declares no `attributes`. A name that names an alias is not
+    -- missing either: `_validate_map` moves its value to the field that
+    -- declares the alias and clears the alias spelling, the same way it
+    -- clears a deprecated key, so look for the value under that field. The
+    -- merge reports which declared name each spelling resolves to, so that
+    -- is one lookup rather than a second walk over the descriptors. It goes
+    -- through `_lookup`, the same as every other name comparison in this
+    -- module, so a hyphen in one spelling and an underscore in the other
+    -- still match.
+    --
+    -- This asks what the shortcode receives, not what the author wrote, so
+    -- a `default` present in `merged.attributes` satisfies a name here.
+    -- That is the opposite of `dependentRequired` above, which asks what
+    -- the author wrote and treats a default as an annotation nobody
+    -- supplied. Neither reading is a bug: they answer different questions
+    -- about the same instance.
+    local function _required_satisfied(required)
+      local field = (spellings and _lookup(spellings, required)) or required
+      if _lookup(merged.attributes, field) ~= nil then
+        return true
+      end
+      if not declared then
+        return _lookup(kwargs or {}, required) ~= nil
+      end
+      return false
+    end
+
+    for _, required in ipairs(entry.required) do
+      if not _required_satisfied(required) then
+        _report(context, 'error', name .. '.' .. required, 'required',
+          'is required but was not provided.')
+      end
+    end
+  end
+
+  return _finish(context, merged)
+end
+
+--- Validate Pandoc element attributes against one group of the `attributes`
+--- section. Undeclared attributes are ignored by default, because a Pandoc
+--- element legitimately carries attributes from Quarto and other filters.
+--- @param attributes table Map of attribute values
+--- @param group string Group key, such as a class, identifier or element name
+--- @param schema table Loaded schema
+--- @param options table|nil {unknown = 'warn'|'error'|'ignore'}
+--- @return boolean valid
+--- @return table errors
+--- @return table warnings
+--- @return table merged
+--- @return table findings
+--- @usage local valid, errors, warnings, merged = M.validate_attributes(el.attributes, 'callout-note', schema)
+function M.validate_attributes(attributes, group, schema, options)
+  options = options or {}
+  local descriptors = schema and schema.attributes and _lookup(schema.attributes, group) or nil
+
+  local context = _new_context()
+  if descriptors == nil then
+    return _finish(context, attributes or {})
+  end
+
+  local merged = _validate_map(attributes or {}, descriptors, group, context, {
+    unknown = options.unknown or 'ignore',
+  })
+  return _finish(context, merged)
+end
+
+--- Validate the options of one output format against the `formats` section.
+--- @param meta table Document metadata
+--- @param format string Format name, such as 'html' or 'typst'
+--- @param schema table Loaded schema
+--- @param options table|nil {unknown = 'warn'|'error'|'ignore'}
+--- @return boolean valid
+--- @return table errors
+--- @return table warnings
+--- @return table merged
+--- @return table findings
+--- @usage local valid, errors, warnings, merged = M.validate_format(meta, 'typst', schema)
+function M.validate_format(meta, format, schema, options)
+  options = options or {}
+  local descriptors = schema and schema.formats and _lookup(schema.formats, format) or nil
+
+  local context = _new_context()
+  if descriptors == nil then
+    return _finish(context, {})
+  end
+
+  local values = {}
+  local format_meta = meta and _lookup(meta, format)
+  if format_meta ~= nil then
+    for key, value in pairs(format_meta) do
+      values[tostring(key)] = _convert_pandoc_value(value)
+    end
+  end
+
+  local merged = _validate_map(values, descriptors, format, context, {
+    unknown = options.unknown or 'ignore',
+  })
+  return _finish(context, merged)
+end
+
+--- Extract an extension's options from document metadata.
+--- Reads `meta.extensions[extension_name]` and converts Pandoc values to
+--- native Lua values, keeping every key exactly as the document wrote it.
+--- @param meta table Document metadata
+--- @param extension_name string Extension name
+--- @return table Map of option values
+--- @usage local options = M.extract_meta_options(meta, 'iconify')
+function M.extract_meta_options(meta, extension_name)
+  local extension_meta = meta and meta['extensions'] and meta['extensions'][extension_name]
+  if not extension_meta then
+    return {}
+  end
+
+  local options = {}
+  for key, value in pairs(extension_meta) do
+    options[tostring(key)] = _convert_pandoc_value(value)
+  end
+  return options
+end
+
+--- Load a schema, validate an extension's options, and log the outcome.
+--- A schema that cannot be loaded is reported and the render continues with
+--- no validated options, rather than aborting on a configuration file.
+--- @param meta table Document metadata
+--- @param extension_name string Extension name
+--- @param schema_path string Path to the schema file, resolved by the caller
+--- @param options table|nil {unknown = 'warn'|'error'|'ignore'}
+--- @return table merged Validated options with defaults applied
+--- @usage local options = M.validate_options(meta, 'iconify', quarto.utils.resolve_path('_schema.yml'))
+function M.validate_options(meta, extension_name, schema_path, options)
+  local schema, err = M.load_schema(schema_path)
+  if err then
+    _env.report_error(string.format('Extension "%s": %s', extension_name, err))
+    return {}
+  end
+
+  if not schema.options or next(schema.options) == nil then
+    return {}
+  end
+
+  local values = M.extract_meta_options(meta, extension_name)
+  local valid, errors, warnings, merged = M.validate(values, schema.options, options)
+
+  if #warnings > 0 then
+    _env.warn(M.format_warnings(warnings, extension_name))
+  end
+  if not valid then
+    _env.report_error(M.format_errors(errors, extension_name))
+  end
+
+  return merged
+end
+
+--- Format error messages as one readable block.
+--- @param errors table Array of error strings
+--- @param extension_name string|nil Extension name for context
+--- @return string Formatted message, or an empty string
+--- @usage local message = M.format_errors(errors, 'iconify')
+function M.format_errors(errors, extension_name)
+  if #errors == 0 then
+    return ''
+  end
+
+  local prefix = extension_name and ('Extension "' .. extension_name .. '": ') or ''
+  local lines = {}
+  for index, message in ipairs(errors) do
+    table.insert(lines, '  ' .. index .. '. ' .. message)
+  end
+
+  return prefix .. 'Configuration validation failed:\n' .. table.concat(lines, '\n')
+end
+
+--- Format warning messages as one readable block.
+--- @param warnings table Array of warning strings
+--- @param extension_name string|nil Extension name for context
+--- @return string Formatted message, or an empty string
+--- @usage local message = M.format_warnings(warnings, 'iconify')
+function M.format_warnings(warnings, extension_name)
+  if #warnings == 0 then
+    return ''
+  end
+
+  local prefix = extension_name and ('Extension "' .. extension_name .. '": ') or ''
+  local lines = {}
+  for index, message in ipairs(warnings) do
+    table.insert(lines, '  ' .. index .. '. ' .. message)
+  end
+
+  return prefix .. 'Configuration warnings:\n' .. table.concat(lines, '\n')
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/tests/_extensions/mcanouil/extension-test/dependencies-schema.yml
+++ b/tests/_extensions/mcanouil/extension-test/dependencies-schema.yml
@@ -1,0 +1,79 @@
+# Descriptors for an extension's `_dependencies.yml`.
+#
+# A vendored file carries no trace of where it came from. This format records
+# that trace: for each source, an origin, the version taken, and for each file
+# a checksum and the runtime it needs.
+#
+# `sources` and `files` are maps with author-chosen keys, so both are expressed
+# with `propertyNames` and an `additionalProperties` descriptor rather than a
+# fixed set of options.
+#
+# The format is public and the tooling that writes it is not, so nothing here
+# may assume a particular producer wrote the file.
+
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
+
+options:
+  schema:
+    type: integer
+    required: true
+    minimum: 1
+    description: "The manifest format version. The runner reads version 1 and skips any other."
+
+  sources:
+    type: object
+    required: true
+    propertyNames: '^[a-z][a-z0-9-]*$'
+    description: "Each upstream this extension vendors from, keyed by a short name."
+    additionalProperties:
+      type: object
+      properties:
+        origin:
+          type: string
+          required: true
+          minLength: 1
+          description: "The upstream's home, such as a repository URL."
+        fetch:
+          type: string
+          required: true
+          minLength: 1
+          pattern: '\{file\}'
+          description: "URL template for one file, with {origin}, {version} and {file}."
+        version:
+          type: string
+          required: true
+          minLength: 1
+          description: "The version every file below was taken at."
+        licence:
+          type: string
+          required: true
+          minLength: 1
+          description: "The licence the upstream ships under, such as MIT."
+        licence-url:
+          type: string
+          description: "URL template for the licence file. Defaults to {origin}/raw/{version}/LICENSE."
+        # The format declares a flat set of files: a key holds a file name and
+        # never a path, so it carries no `/`. Both current upstreams ship a
+        # flat file set, and the validator's pattern engine cannot express the
+        # test that rejects `..` inside a path safely. A key that must not
+        # travel is better than a key that travels unchecked.
+        files:
+          type: object
+          required: true
+          propertyNames: '^[A-Za-z0-9._-]+$'
+          description: "Each file vendored from this source, keyed by its file name."
+          additionalProperties:
+            type: object
+            properties:
+              sha256:
+                type: string
+                required: true
+                pattern: '^[0-9a-fA-F]+$'
+                minLength: 64
+                maxLength: 64
+                description: "The SHA-256 of the file as written."
+              runtime:
+                type: string
+                enum: [any, pandoc]
+                default: any
+                description: "`pandoc` when the file needs a library only Pandoc provides."

--- a/tests/_extensions/mcanouil/extension-test/manifest-schema.yml
+++ b/tests/_extensions/mcanouil/extension-test/manifest-schema.yml
@@ -1,0 +1,49 @@
+# Descriptors for an extension's `_extension.yml`.
+#
+# Quarto publishes no meta-schema for `_extension.yml`, so this file supplies
+# one in the same v2 vocabulary the runner already validates `_schema.yml`
+# with. Reusing the validator means there is one implementation of the
+# keyword semantics rather than two, and this file is itself checked by the
+# conformance layer when the framework tests itself.
+#
+# The `contributes` key allowlist is deliberately NOT expressed as
+# `propertyNames` here. An unrecognised contribution key is reported as a
+# warning by `conformance.lua`, not an error, because the full set Quarto
+# accepts has not been confirmed against the CLI source. Promote it to
+# `propertyNames` once it has.
+#
+# `version` avoids an optional group: the reference validator refuses a
+# quantifier applied to a group and fails closed, so the pre-release and
+# build suffixes are matched with a character class instead.
+
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
+
+options:
+  title:
+    type: string
+    required: true
+    minLength: 1
+    description: "The extension's display name."
+
+  author:
+    type: [string, array]
+    required: true
+    items:
+      type: string
+    description: "The extension's author, or a list of authors."
+
+  version:
+    type: string
+    required: true
+    pattern: '^[0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.+-]*$'
+    description: "A semantic version, such as `1.4.0` or `2.0.0-beta.1`."
+
+  quarto-required:
+    type: string
+    pattern: '^[<>=~^ .0-9|*x-]+$'
+    description: "The Quarto version range the extension supports, such as `>=1.8.0`."
+
+  contributes:
+    type: object
+    required: true
+    description: "What the extension contributes: shortcodes, filters, formats, project, metadata, revealjs-plugins."

--- a/tests/_extensions/mcanouil/extension-test/run.lua
+++ b/tests/_extensions/mcanouil/extension-test/run.lua
@@ -1,0 +1,436 @@
+--- Extension Test - Test runner for Quarto extensions.
+--- @version 0.0.0
+---
+--- Run from a repository root:
+---
+---     quarto pandoc lua tests/_extensions/*/extension-test/run.lua
+---
+--- The runner drives Quarto rather than running inside it. That is not a
+--- style choice: Quarto builds its extension registry while reading
+--- `_quarto.yml`, before any `pre-render` script runs, so an extension staged
+--- from inside a render is not seen by that render.
+
+local script_dir = (function()
+  local self = arg and arg[0]
+  if not self then
+    local info = debug.getinfo(1, 'S')
+    self = info and info.source and info.source:gsub('^@', '')
+  end
+  local dir = pandoc.path.directory(self or '.')
+  if pandoc.path.is_absolute(dir) then
+    return dir
+  end
+  return pandoc.path.normalize(pandoc.path.join({ pandoc.system.get_working_directory(), dir }))
+end)()
+
+package.path = table.concat({
+  pandoc.path.join({ script_dir, '_modules', '?.lua' }),
+  pandoc.path.join({ script_dir, '_vendor', 'quarto-wizard', '?.lua' }),
+  package.path,
+}, ';')
+
+local util = require('util')
+local report = require('report')
+local conformance = require('conformance')
+local render = require('render')
+local generate = require('generate')
+local stage = require('stage')
+local schema = require('schema')
+
+--- The version the extension manifest declares. The release workflow rewrites
+--- `_extension.yml`, and nothing rewrites a constant, so a constant here goes
+--- stale at the first release and tells the catalogue the wrong thing.
+local VERSION = (function()
+  local text = util.read_file(pandoc.path.join({ script_dir, '_extension.yml' }))
+  if not text then
+    return 'unknown'
+  end
+  local ok, parsed = pcall(schema._parse_yaml_text, text)
+  if not ok or type(parsed) ~= 'table' or parsed.version == nil then
+    return 'unknown'
+  end
+  return tostring(parsed.version)
+end)()
+local LAYERS = { conformance = true, render = true, smoke = true }
+
+local USAGE = [[
+Test a Quarto extension.
+
+Usage:
+  quarto pandoc lua tests/_extensions/*/extension-test/run.lua [options]
+
+Options:
+  --root <dir>          Repository root. Default: the parent of the tests directory.
+  --tests <dir>         Tests directory. Default: detected from this script's location.
+  --layer <name>        conformance, render or smoke. Repeatable. Default: all.
+  --severity <level>    strict or lenient. Default: strict.
+  --max-generated <n>   Cap generated documents per extension. Default: 200.
+  --keep-generated      Leave the generated documents in place for inspection.
+  --json <path>         Write the result JSON. Default: tests/_results/results.json.
+  --tap <path>          Write TAP 13. `-` means stdout. Default: stdout.
+  --list                Print the plan and run nothing.
+  --quiet               Suppress the human summary on stderr.
+  --version             Print the framework version.
+  --help                Print this message.
+
+Exit codes:
+  0  every case passed or was skipped
+  1  at least one case failed
+  2  the harness could not run
+]]
+
+--- Parse the command line.
+--- @param argv string[]
+--- @return table|nil options, string|nil error
+local function parse_args(argv)
+  local options = {
+    layers = {},
+    severity = 'strict',
+    tap = '-',
+    list = false,
+    quiet = false,
+    max_generated = 200,
+    keep_generated = false,
+  }
+
+  local index = 1
+  while index <= #argv do
+    local flag = argv[index]
+    --- Reading past the end silently leaves the option unset, so a mistyped
+    --- invocation would write results somewhere the caller never asked for.
+    local missing = false
+    local function value()
+      index = index + 1
+      if argv[index] == nil then
+        missing = true
+      end
+      return argv[index]
+    end
+
+    if flag == '--root' then
+      options.root = value()
+    elseif flag == '--tests' then
+      options.tests = value()
+    elseif flag == '--layer' then
+      local name = value()
+      if not name or not LAYERS[name] then
+        return nil, string.format('unknown layer `%s`', tostring(name))
+      end
+      options.layers[#options.layers + 1] = name
+    elseif flag == '--severity' then
+      local level = value()
+      if level ~= 'strict' and level ~= 'lenient' then
+        return nil, string.format('unknown severity `%s`', tostring(level))
+      end
+      options.severity = level
+    elseif flag == '--max-generated' then
+      local count = tonumber(value())
+      if not count or count < 1 then
+        return nil, '--max-generated needs a positive integer'
+      end
+      options.max_generated = math.floor(count)
+    elseif flag == '--keep-generated' then
+      options.keep_generated = true
+    elseif flag == '--json' then
+      options.json = value()
+    elseif flag == '--tap' then
+      options.tap = value()
+    elseif flag == '--list' then
+      options.list = true
+    elseif flag == '--quiet' then
+      options.quiet = true
+    elseif flag == '--version' then
+      options.print_version = true
+    elseif flag == '--help' or flag == '-h' then
+      options.print_help = true
+    else
+      return nil, string.format('unknown option `%s`', tostring(flag))
+    end
+    if missing then
+      return nil, string.format('`%s` needs a value', tostring(flag))
+    end
+    index = index + 1
+  end
+
+  if #options.layers == 0 then
+    options.layers = { 'conformance', 'render', 'smoke' }
+  end
+  return options, nil
+end
+
+--- Resolve the tests directory and repository root.
+---
+--- The script lives at `<tests>/_extensions/<owner>/<name>/run.lua`, so the
+--- tests directory is three levels up and the repository root is its parent.
+--- Both are overridable, because the listing runs its own pinned copy against
+--- a repository it did not install into.
+---
+--- Both are made absolute. The render layer inspects a document from inside
+--- the tests directory, so a path relative to the caller's working directory
+--- would name a file that is not there.
+--- @param options table
+local function resolve_paths(options)
+  if not options.tests then
+    local owner_dir = pandoc.path.directory(script_dir)
+    local extensions_dir = pandoc.path.directory(owner_dir)
+    options.tests = pandoc.path.directory(extensions_dir)
+  end
+  options.tests = util.absolute(options.tests)
+  if not options.root then
+    options.root = pandoc.path.directory(options.tests)
+  end
+  options.root = util.absolute(options.root)
+  options.extension_dir = script_dir
+end
+
+--- Detect the Quarto version and channel.
+--- @return table
+local function quarto_environment()
+  local code, output = util.capture('quarto --version')
+  local version = util.trim(output)
+  if code ~= 0 then
+    version = 'unknown'
+  end
+  -- Quarto marks a pre-release with a four-part version or a `-` suffix.
+  local channel = 'release'
+  if version:match('%-') or version:match('^%d+%.%d+%.%d+%.%d+') then
+    channel = 'prerelease'
+  end
+  return { version = version, channel = channel }
+end
+
+--- Read the `test:` descriptors the framework ships.
+--- @param options table
+--- @return table descriptors
+local function load_test_descriptors(options)
+  local loaded, load_err = schema.load_schema(util.join(options.extension_dir, 'test-schema.yml'))
+  if loaded then
+    return loaded.options
+  end
+  io.stderr:write('warning: cannot read the `test:` descriptors: ' .. tostring(load_err) .. '\n')
+  return {}
+end
+
+--- Run the smoke layer: generate documents from each schema, render them,
+--- and remove them again.
+---
+--- Generation happens inside the staged project, so the generated documents
+--- resolve the extension under test exactly as an authored one would.
+--- @param options table
+--- @param extensions table[]
+--- @param descriptors table
+--- @param emit function(case)
+local function run_smoke(options, extensions, descriptors, emit)
+  local usable = {}
+  for _, ext in ipairs(extensions) do
+    if type(ext.schema) == 'table' then
+      usable[#usable + 1] = ext
+    end
+  end
+
+  if #usable == 0 then
+    emit({
+      id = 'smoke/discover',
+      layer = 'smoke',
+      status = 'skip',
+      failure = {
+        stage = 'discover',
+        reason = 'no-usable-schema',
+        message = 'no extension ships a v2 `_schema.yml` to generate from',
+      },
+    })
+    return
+  end
+
+  local staged, stage_err = stage.stage(options.root, options.tests)
+  if stage_err or #staged.names == 0 then
+    -- Undone on the error path too: a part-copied extension left behind would
+    -- be rendered by anything else that looks at the tree before the next run.
+    stage.unstage(options.tests)
+    emit({
+      id = 'smoke/stage',
+      layer = 'smoke',
+      status = stage_err and 'fail' or 'skip',
+      failure = {
+        stage = 'stage',
+        reason = stage_err and 'staging-failed' or 'nothing-to-stage',
+        message = stage_err or 'the repository ships no extension to stage',
+      },
+    })
+    return
+  end
+
+  local missing = stage.missing_project(options.tests)
+  if missing then
+    stage.unstage(options.tests)
+    emit({
+      id = 'smoke/stage',
+      layer = 'smoke',
+      status = 'fail',
+      failure = { stage = 'stage', reason = 'no-project-file', message = missing },
+    })
+    return
+  end
+
+  local ok, err = pcall(function()
+    local planned, skips = {}, {}
+    for _, ext in ipairs(usable) do
+      local documents, extension_skips = generate.plan(ext, ext.manifest, options.max_generated)
+      for _, doc in ipairs(documents) do
+        planned[#planned + 1] = doc
+      end
+      for _, skip in ipairs(extension_skips) do
+        skips[#skips + 1] = skip
+      end
+    end
+
+    -- Every skip is reported. A cap or an underivable value that went
+    -- unmentioned would read as coverage that never happened.
+    for _, skip in ipairs(skips) do
+      emit({
+        id = skip.id,
+        layer = 'smoke',
+        status = 'skip',
+        failure = { stage = 'generate', reason = skip.reason, message = skip.message },
+      })
+    end
+
+    if #planned == 0 then
+      return
+    end
+
+    local _, written, write_err = generate.write(options.tests, planned)
+    if write_err then
+      emit({
+        id = 'smoke/write',
+        layer = 'smoke',
+        status = 'fail',
+        failure = { stage = 'generate', reason = 'write-failed', message = write_err },
+      })
+      return
+    end
+
+    local documents = {}
+    for _, relative in ipairs(written) do
+      documents[#documents + 1] = {
+        relative = relative,
+        absolute = util.join(options.tests, relative),
+        origin = 'generated',
+      }
+    end
+    render.execute(options, documents, descriptors, 'smoke', emit)
+  end)
+
+  if not options.keep_generated then
+    generate.clean(options.tests)
+  end
+  stage.unstage(options.tests)
+
+  if not ok then
+    emit({
+      id = 'smoke/harness',
+      layer = 'smoke',
+      status = 'fail',
+      failure = { stage = 'generate', reason = 'harness-error', message = tostring(err) },
+    })
+  end
+end
+
+local function main(argv)
+  local options, parse_err = parse_args(argv)
+  if not options then
+    io.stderr:write('error: ' .. parse_err .. '\n\n' .. USAGE)
+    return 2
+  end
+  if options.print_help then
+    io.write(USAGE)
+    return 0
+  end
+  if options.print_version then
+    io.write(VERSION, '\n')
+    return 0
+  end
+
+  resolve_paths(options)
+
+  if not util.is_dir(options.root) then
+    io.stderr:write(string.format('error: repository root `%s` is not a directory\n', options.root))
+    return 2
+  end
+
+  local results = report.new({
+    framework = { name = 'extension-test', version = VERSION },
+    extension = { root = options.root },
+    quarto = quarto_environment(),
+    environment = {
+      severity = options.severity,
+      tests = options.tests,
+    },
+  })
+
+  if options.list then
+    io.write(string.format('root:     %s\ntests:    %s\nlayers:   %s\nseverity: %s\n',
+      options.root, options.tests, table.concat(options.layers, ', '), options.severity))
+    for _, ext in ipairs(conformance.discover(options.root)) do
+      io.write('extension: ', ext.name, '\n')
+    end
+    return 0
+  end
+
+  local function emit(entry)
+    report.add(results, entry)
+  end
+
+  local extensions = {}
+  if util.contains(options.layers, 'conformance') then
+    extensions = conformance.run(options, emit)
+  elseif util.contains(options.layers, 'smoke') then
+    -- The smoke layer generates from the schema, so it has to be loaded even
+    -- when the layer that reports on it was not asked for.
+    extensions = conformance.load(options.root)
+  else
+    extensions = conformance.discover(options.root)
+  end
+
+  if util.contains(options.layers, 'render') then
+    render.run(options, load_test_descriptors(options), emit)
+  end
+
+  if util.contains(options.layers, 'smoke') then
+    run_smoke(options, extensions, load_test_descriptors(options), emit)
+  end
+
+  local names = {}
+  for _, ext in ipairs(extensions) do
+    names[#names + 1] = ext.name
+  end
+  results.extension.names = names
+
+  report.finalise(results)
+
+  local json_path = options.json or util.join(options.tests, '_results', 'results.json')
+  local written, write_err = util.write_file(json_path, report.to_json(results) .. '\n')
+  if not written then
+    io.stderr:write('error: cannot write results: ' .. tostring(write_err) .. '\n')
+    return 2
+  end
+
+  local tap = report.to_tap(results)
+  if options.tap == '-' then
+    io.write(tap)
+  elseif options.tap then
+    util.write_file(options.tap, tap)
+  end
+
+  if not options.quiet then
+    io.stderr:write(report.to_summary(results))
+  end
+
+  if pandoc.system.environment()['GITHUB_ACTIONS'] == 'true' then
+    io.stderr:write(report.to_annotations(results))
+  end
+
+  return results.status == report.FAIL and 1 or 0
+end
+
+os.exit(main(arg or {}), true)

--- a/tests/_extensions/mcanouil/extension-test/test-schema.yml
+++ b/tests/_extensions/mcanouil/extension-test/test-schema.yml
@@ -1,0 +1,61 @@
+# The `test:` front-matter vocabulary.
+#
+# Written in the same v2 vocabulary the runner validates `_schema.yml` with,
+# so the framework's own configuration is checked by the validator whose
+# behaviour the framework exists to protect. It also gives Quarto Wizard
+# completion inside a `test:` block at no extra cost.
+#
+# Every key is optional. A test document with no `test:` block behaves as
+# `test: {}`: rendered to every format `quarto inspect` reports, strictly,
+# expecting success. That is the zero-authoring case.
+#
+# The vocabulary is additive only. The catalogue sweep runs one pinned
+# framework version against repositories that pinned an older one, so a key
+# this version does not know must warn and be ignored rather than fail.
+# `schema` carries the vocabulary version for the same reason.
+
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
+
+options:
+  schema:
+    type: integer
+    default: 1
+    minimum: 1
+    description: "The `test:` vocabulary version this document is written against."
+
+  name:
+    type: string
+    description: "A human name for the case. Defaults to the document's file stem."
+
+  description:
+    type: string
+    default: ""
+    description: "What the case covers."
+
+  formats:
+    type: [string, array]
+    items:
+      type: string
+    description: "Target formats. Defaults to every format `quarto inspect` reports for the document."
+
+  skip:
+    type: [boolean, string]
+    default: false
+    description: "Skip the case. A string is reported as the reason."
+
+  expect:
+    type: string
+    enum: [pass, fail]
+    default: pass
+    description: "Whether the render is expected to succeed. `fail` passes the case when the render fails."
+
+  strict:
+    type: boolean
+    default: true
+    description: "Fail on an error in the render log. `false` reports errors without failing."
+
+  timeout:
+    type: integer
+    default: 300
+    minimum: 1
+    description: "Seconds allowed per format."

--- a/tests/_quarto.yml
+++ b/tests/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: extension-test

--- a/tests/schema-defaults.lua
+++ b/tests/schema-defaults.lua
@@ -10,7 +10,7 @@
 ---     quarto pandoc lua tests/schema-defaults.lua
 
 local root = (arg and arg[0] or 'tests/schema-defaults.lua'):match('(.*/)tests/') or './'
-local schema = assert(dofile(root .. '_extensions/iconify/_modules/schema.lua'))
+local schema = assert(dofile(root .. '_extensions/iconify/_vendor/quarto-wizard/schema.lua'))
 
 local loaded, load_error = schema.load_schema(root .. '_extensions/iconify/_schema.yml')
 if load_error then
@@ -60,7 +60,7 @@ end
 --- with `required` on the first argument.
 ---
 --- These checks cover the schema half only: that the flag is declared, and
---- that the validator counts both an absent and an empty argument as missing.
+--- what the validator does with an absent and with an empty argument.
 --- The Lua that acts on it, the guard in `render_icon` and the report in
 --- `validate_call`, is not exercised here, because loading `iconify.lua`
 --- needs the `quarto` runtime this suite deliberately does without. Removing
@@ -79,23 +79,30 @@ else
   failed = failed + 1
 end
 
---- A call with no argument, and a call whose argument is empty, must both be
---- reported. The schema treats an empty string as missing, and the Lua guard
---- reads the same way, so the two never disagree about what "no icon" means.
-for _, case in ipairs({ { name = 'no argument', args = {} },
-                        { name = 'empty argument', args = { '' } } }) do
+--- The validator reports an absent argument and says nothing about an empty
+--- one. `required` asks whether the author wrote the argument, and an empty
+--- string is something they wrote.
+---
+--- The extension still rejects both. `validate_call` in `iconify.lua` runs its
+--- own `str.is_empty` check rather than reading this finding, which is why
+--- narrowing `required` in the validator did not change what an author sees.
+--- Rendering a document is what proves that half.
+for _, case in ipairs({ { name = 'no argument', args = {}, expected = true },
+                        { name = 'empty argument', args = { '' }, expected = false } }) do
   extra = extra + 1
-  local valid, errors = schema.validate_shortcode('iconify', case.args, {}, iconify_entry)
+  local _, errors = schema.validate_shortcode('iconify', case.args, {}, iconify_entry)
   local reported = false
   for _, message in ipairs(errors or {}) do
     if message:find('required', 1, true) then
       reported = true
     end
   end
-  if not valid and reported then
-    io.stdout:write('ok   iconify with ' .. case.name .. ' is reported as missing\n')
+  if reported == case.expected then
+    io.stdout:write(string.format('ok   iconify with %s: validator reports required = %s\n',
+      case.name, tostring(case.expected)))
   else
-    io.stdout:write('FAIL iconify with ' .. case.name .. ' is not reported as missing\n')
+    io.stdout:write(string.format('FAIL iconify with %s: validator reports required = %s, expected %s\n',
+      case.name, tostring(reported), tostring(case.expected)))
     failed = failed + 1
   end
 end


### PR DESCRIPTION
The vendored Lua modules move from `_extensions/iconify/_modules/` to `_extensions/iconify/_vendor/`, and `_dependencies.yml` records the release each one came from and its digest. `typst.lua` matches no published source, so it stays first party. `vendor.sh --sync` refetches every declared file and verifies it against the recorded digest.

Two files were adopted rather than matched. `string.lua` declared `@version 1.1.0`, which no release published, so the published 2.0.0 file replaces it. `schema.lua` was the Quarto Wizard validator 175 lines behind, and the vendored copy is the one 3.4.0 publishes, 2513 lines against 2338. No author sees a difference from that upgrade: 3.4.0 counts only a missing key as missing, where the old copy also counted an empty string, and `validate_call` in `iconify.lua` makes that check itself.

Three files named a module that moved, and each was repointed by hand:

- `docs/_filters/schema-tables.lua` loaded the validator with `pcall` and returned an empty filter set on failure, so the documentation site would have lost every generated reference table while the render still exited 0.
- `tests/schema-defaults.lua` asserted that the validator counts an empty argument as missing. It now asserts the 3.4.0 rule.
- `_extensions/iconify/_modules/typst.lua` built its module path at run time, so `vendor.sh` matched no literal reference and reported nothing. The render failed outright. It now loads the two modules the way `iconify.lua` does.

`tests/` becomes a Quarto project holding the extension test framework, installed from its default branch because it has no release, and `.github/workflows/test.yml` calls its reusable workflow with `contents: read`.

Being that workflow's first external caller found two problems in it. Its `issue` job asked for `issues: write` behind an `if`, and a called job cannot request more than its caller grants, so every run ended in `startup_failure` in one second. That is fixed upstream and the job now lives in a separate workflow a repository opts into. Its render layer still skips both of its own cases with `output-not-found`, because it looks for an output named after the source document while `example.qmd` sets `output-file:`, so that layer asserts nothing here. The second one is filed and not solved.

`docs/_scripts/sync-extension.sh` also carried the scaffolder's `%%license%%`, `%%year%%` and `%%author%%` placeholders in its header, which the scaffolder's own check could not see. That check is fixed upstream and this header is corrected here.