### PR TITLE
refactor: check the document against the schema with the shared module

### DIFF
--- a/_extensions/iconify/_dependencies.yml
+++ b/_extensions/iconify/_dependencies.yml
@@ -3,17 +3,20 @@ sources:
   quarto-lua-modules:
     origin: "https://github.com/mcanouil/quarto-lua-modules"
     fetch: "{origin}/releases/download/{version}/{file}"
-    version: "2.0.0"
+    version: "2.1.0"
     licence: MIT
     files:
       logging.lua:
-        sha256: "a69a69ce7cf41b02914889074eb7445cff72003e6dd8b55b6f47d32d09848ccd"
+        sha256: "0c3ded6020d3739c91bb6a492328751b284d1ada5763a1b8ca6fc5536ac01c95"
         runtime: any
       metadata.lua:
-        sha256: "3f82a6208c337ae9a2e4a0a6f294f894cc506e05aedfb1c13167e55b52b8c457"
+        sha256: "f42599d322e3ea68c247078da26959041f3fdebf0aa4d406a415240a2a0f6ddd"
+        runtime: any
+      schema-check.lua:
+        sha256: "2fda875db97479f69c2c4d49f3073ac6ec458cb502c08c380918fdfadcd1e799"
         runtime: any
       string.lua:
-        sha256: "32b2c16f50ecf7e752441ed80bd7fbcee11af83c4ed1e9242cc745d200bc73e0"
+        sha256: "a80255adaf7b7f2588aecb127030d950379479a2a1b266efc5b943364ac96cf4"
         runtime: any
   quarto-wizard:
     origin: "https://github.com/mcanouil/quarto-wizard"

--- a/_extensions/iconify/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.0.0
+--- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/iconify/_vendor/quarto-lua-modules/metadata.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/metadata.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.0.0
+--- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/iconify/_vendor/quarto-lua-modules/schema-check.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/schema-check.lua
@@ -1,0 +1,346 @@
+--- MC Schema Check - Runtime schema checks for Quarto extensions
+--- @module "schema-check"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 2.1.0
+---
+--- Holds the wiring that every extension would otherwise copy: read
+--- `_schema.yml` once, check the document configuration against it, check one
+--- shortcode call against it, and report what it finds through `logging`.
+---
+--- The validator arrives as an argument rather than through `require`. A
+--- vendored copy of this module then knows nothing about where the validator
+--- was vendored, so the two sources stay independent. The validator must
+--- provide `load_schema`, `validate`, `validate_shortcode` and
+--- `extract_meta_options`.
+---
+--- Nothing here stops a render. A schema is configuration, and a fault in the
+--- configuration must not remove the document.
+
+local M = {}
+
+--- Load a sibling module from the same directory as this file.
+--- @param filename string The sibling module filename (e.g., 'string.lua')
+--- @return table The loaded module
+local function load_sibling(filename)
+  local source = debug.getinfo(1, 'S').source:sub(2)
+  local dir = source:match('(.*[/\\])') or ''
+  return require((dir .. filename):gsub('%.lua$', ''))
+end
+
+--- Load required modules
+local log = load_sibling('logging.lua')
+local str = load_sibling('string.lua')
+
+-- ============================================================================
+-- SEVERITY
+-- ============================================================================
+
+--- The level each kind of finding is reported at. This is the only place a
+--- severity is decided, so a later change to what an extension must correct is
+--- a change to this table and nothing else.
+---
+--- The current policy reports and never stops a render. A finding is a warning,
+--- with two exceptions. An unreadable schema is an error, because no check runs
+--- after it. A missing required argument is an error, because the shortcode
+--- renders nothing without it, which is the one finding that changes the
+--- document.
+---
+--- A rejected document option keeps the error level it has today: it names a
+--- value the extension cannot use, and the author has to correct it.
+--- @type table<string, string>
+local SEVERITY = {
+  schema = 'error',
+  option_error = 'error',
+  option_warning = 'warning',
+  call_error = 'warning',
+  call_warning = 'warning',
+  missing_argument = 'error',
+}
+
+--- The reporting function for each level.
+--- @type table<string, function>
+local REPORTERS = {
+  error = log.log_error,
+  warning = log.log_warning,
+}
+
+-- A level with no reporter is the mistake a change to `SEVERITY` makes, and it
+-- is caught here, at load, rather than at the one render that reaches that kind
+-- of finding.
+for kind, level in pairs(SEVERITY) do
+  assert(REPORTERS[level] ~= nil,
+    string.format('schema-check: "%s" maps to the unknown level "%s"', kind, tostring(level)))
+end
+
+-- ============================================================================
+-- PRIVATE HELPERS
+-- ============================================================================
+
+--- Read an attribute value with a surrounding quote pair removed.
+--- Quarto's body parser strips those quotes before the value reaches the
+--- shortcode, but the parser it uses for a text or attribute string hands the
+--- raw token over instead, so `aria-hidden='true'` arrives as the five
+--- character string `'true'`. Stripping here is what makes a quoted and an
+--- unquoted value check as the same thing.
+--- @param kwargs table<string, any> Key-value options for the call
+--- @param key string The attribute name to read
+--- @return string
+local function attr_value(kwargs, key)
+  --- @type string
+  local value = str.stringify(kwargs[key])
+  --- @type string
+  local quote = value:sub(1, 1)
+  if #value > 1 and (quote == '"' or quote == "'") and value:sub(-1) == quote then
+    return value:sub(2, -2)
+  end
+  return value
+end
+
+--- Copy a value, and every table inside it, all the way down.
+--- The copy exists so that a caller writing into what it received cannot
+--- change what every later reader of the same checker sees.
+---
+--- The depth comes from the schema format, not from the schemas written so
+--- far. The vocabulary allows `type: array` and `type: object`, and the
+--- validator compiles a declared `default` by coercing it against that type
+--- and returning it untouched once it already matches. Any option declaring a
+--- collection type with a literal default therefore resolves to a Lua table,
+--- at whatever depth the schema nests it, so a copy one level deep would hand
+--- two callers the same inner table and leave the fault one level down.
+---
+--- A table already copied on this walk is reused rather than copied again,
+--- which keeps shared structure shared and makes a cycle terminate. A schema
+--- file cannot express a cycle, because the validator's parser refuses anchors
+--- and aliases, but the validator is injected and what it returns is not this
+--- module's to assume.
+--- @param value any The value to copy
+--- @param seen table|nil Tables already copied on this walk
+--- @return any
+local function deep_copy(value, seen)
+  if type(value) ~= 'table' then
+    return value
+  end
+  seen = seen or {}
+  if seen[value] ~= nil then
+    return seen[value]
+  end
+  --- @type table
+  local copy = {}
+  seen[value] = copy
+  for key, item in pairs(value) do
+    copy[key] = deep_copy(item, seen)
+  end
+  return copy
+end
+
+--- Flatten a call's named options to plain strings for the validator.
+--- @param kwargs table<string, any> Key-value options for the call
+--- @return table<string, string>
+local function plain_kwargs(kwargs)
+  --- @type table<string, string>
+  local plain = {}
+  for key in pairs(kwargs) do
+    plain[tostring(key)] = attr_value(kwargs, key)
+  end
+  return plain
+end
+
+-- ============================================================================
+-- CHECKER
+-- ============================================================================
+
+--- @class Checker
+--- @field validator table The validator the caller injected
+--- @field extension string The extension name every message carries
+--- @field schema table|nil The parsed schema, nil when it could not be read
+--- @field defaults table<string, any> The defaults the schema declares
+--- @field resolved table|nil The three tables the configuration resolves to
+--- @field options_checked boolean Whether the configuration was already checked
+local Checker = {}
+Checker.__index = Checker
+
+--- Report one finding at the level its kind is mapped to.
+--- A kind with no entry in `SEVERITY` is a fault in this module, and it says so
+--- rather than reporting the finding at a level nobody chose. It is reported
+--- rather than raised, because a fault here must not remove a document.
+--- @param kind string A key of `SEVERITY`
+--- @param message string The message to report
+--- @return nil
+function Checker:_report(kind, message)
+  --- @type string|nil
+  local level = SEVERITY[kind]
+  if level == nil then
+    log.log_error(self.extension, string.format(
+      'schema-check has no severity for "%s": %s', tostring(kind), message))
+    return
+  end
+  REPORTERS[level](self.extension, message)
+end
+
+--- Check the document configuration and return what it resolves to. The check
+--- runs once, so an extension can ask on every shortcode without repeating the
+--- messages.
+---
+--- The defaults come first, because that is what most extensions want, and
+--- because the schema is the one place they are written. They come from a
+--- second pass over an empty table, which yields the declared defaults alone.
+---
+--- The second return holds three tables, because they answer different
+--- questions:
+---   provided  what the document actually set, which is the only way to tell
+---             a deliberate `false` or `0` from an absent key,
+---   merged    the same values with coercion and defaults applied,
+---   defaults  the schema defaults on their own.
+--- It is nil when there is nothing to resolve against, so an extension can
+--- tell an unreadable schema from a document that set nothing.
+---
+--- The defaults are a fresh copy on every call, so a caller may treat them as
+--- its own. The tables inside the second return are the checker's, and every
+--- later reader of the same checker sees them, so they must not be written to.
+--- @param meta table<string, any> Document metadata
+--- @return table<string, any> defaults A copy of the defaults, empty when there is no schema
+--- @return table|nil resolved {provided, merged, defaults}, nil when there is no schema
+function Checker:options(meta)
+  if self.options_checked then
+    return deep_copy(self.defaults), self.resolved
+  end
+  self.options_checked = true
+
+  --- @type table|nil
+  local loaded = self.schema
+  -- The validator is injected from an independent source, so the shape of what
+  -- it returns is not this module's to assume. `call` makes the same allowance
+  -- for `shortcodes` one field over.
+  if loaded == nil or next(loaded.options or {}) == nil then
+    return deep_copy(self.defaults), self.resolved
+  end
+
+  --- @type table<string, any>
+  local provided = self.validator.extract_meta_options(meta, self.extension)
+  local valid, errors, warnings, merged = self.validator.validate(provided, loaded.options)
+
+  for _, message in ipairs(warnings) do
+    self:_report('option_warning', message)
+  end
+  if not valid then
+    for _, message in ipairs(errors) do
+      self:_report('option_error', message)
+    end
+  end
+
+  local _, _, _, defaults = self.validator.validate({}, loaded.options, { unknown = 'ignore' })
+  self.defaults = defaults or {}
+  self.resolved = { provided = provided, merged = merged, defaults = self.defaults }
+
+  return deep_copy(self.defaults), self.resolved
+end
+
+--- Check one shortcode call against its entry in the schema.
+--- This reports only. Nothing about the rendered output changes, so an
+--- unrecognised attribute is surfaced rather than dropped.
+--- @param name string Shortcode name
+--- @param args table<integer, any> Positional arguments
+--- @param kwargs table<string, any> Key-value options for the call
+--- @return nil
+function Checker:call(name, args, kwargs)
+  --- @type table|nil
+  local loaded = self.schema
+  if loaded == nil then return end
+
+  --- @type table|nil
+  local entry = loaded.shortcodes and loaded.shortcodes[name]
+  if entry == nil then return end
+
+  args = args or {}
+  kwargs = kwargs or {}
+
+  --- @type table<integer, string>
+  local positional = {}
+  for index, value in ipairs(args) do
+    positional[index] = str.stringify(value)
+  end
+
+  local _, errors, warnings = self.validator.validate_shortcode(
+    name, positional, plain_kwargs(kwargs), entry)
+
+  for _, message in ipairs(warnings) do
+    self:_report('call_warning', message)
+  end
+
+  -- A required argument that is absent is read here rather than out of the
+  -- validator's findings, because the validator reports a nested argument
+  -- fault under one `arguments` entry, which cannot tell a missing argument
+  -- from a malformed one.
+  --- @type table<integer, table>
+  local missing = {}
+  for index, argument in ipairs(entry.arguments or {}) do
+    if argument.required == true and str.is_empty(positional[index]) then
+      missing[#missing + 1] = argument
+    end
+  end
+
+  if #missing > 0 then
+    -- The only message about the missing argument: the schema's own `required`
+    -- wording says the same thing, and reporting both would state one fault
+    -- twice at two severities. Attribute warnings above still stand, and every
+    -- other finding about this call is secondary to there being no output.
+    for _, argument in ipairs(missing) do
+      --- The example comes from the schema, so that each shortcode carries its
+      --- own rather than this message naming one shortcode for all of them.
+      --- @type string
+      local advice = ''
+      local example = type(argument.examples) == 'table' and argument.examples[1] or nil
+      if example ~= nil then
+        advice = string.format(' For example: {{< %s %s >}}.', name, tostring(example))
+      end
+      self:_report('missing_argument', string.format(
+        'The "%s" shortcode needs its "%s" argument.%s', name, argument.name, advice))
+    end
+    return
+  end
+
+  for _, message in ipairs(errors) do
+    self:_report('call_error', message)
+  end
+end
+
+-- ============================================================================
+-- PUBLIC API
+-- ============================================================================
+
+--- Build a checker for one extension, reading `_schema.yml` once.
+--- A schema that cannot be read is reported, and the checker it returns does
+--- nothing: `options` gives an empty table and `call` gives no message.
+--- @param validator table The validator, with `load_schema`, `validate`,
+---   `validate_shortcode` and `extract_meta_options`
+--- @param extension_name string The extension name every message carries
+--- @return Checker
+--- @usage local checker = M.new(validator, 'iconify')
+function M.new(validator, extension_name)
+  --- @type Checker
+  local checker = setmetatable({
+    validator = validator,
+    extension = extension_name,
+    schema = nil,
+    defaults = {},
+    resolved = nil,
+    options_checked = false,
+  }, Checker)
+
+  local loaded, err = validator.load_schema(quarto.utils.resolve_path('_schema.yml'))
+  if err then
+    checker:_report('schema', err)
+  else
+    checker.schema = loaded
+  end
+
+  return checker
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/iconify/_vendor/quarto-lua-modules/string.lua
+++ b/_extensions/iconify/_vendor/quarto-lua-modules/string.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.0.0
+--- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/iconify/iconify.lua
+++ b/_extensions/iconify/iconify.lua
@@ -12,39 +12,22 @@ local log = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/loggin
 local meta_mod = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/metadata.lua'):gsub('%.lua$', ''))
 local typst = require(quarto.utils.resolve_path('_modules/typst.lua'):gsub('%.lua$', ''))
 local schema = require(quarto.utils.resolve_path('_vendor/quarto-wizard/schema.lua'):gsub('%.lua$', ''))
+local check = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/schema-check.lua'):gsub('%.lua$', ''))
 
---- The parsed `_schema.yml`, loaded once and reused by every shortcode call.
---- Nil means the file could not be read, in which case calls are not checked
---- and the render carries on: a configuration file must not stop a document.
---- @type table|nil
-local extension_schema = nil
-
---- Whether loading has already been attempted this render.
---- @type boolean
-local schema_loaded = false
-
---- Last resort for the two values the extension cannot render without, used
---- only when `_schema.yml` could not be read. `_schema.yml` stays the source
---- of truth on every normal path; without these an unreadable configuration
---- file would turn every icon into `icon=":name"` and stop Typst caching.
---- @type table<string, string>
-local SCHEMA_UNAVAILABLE = {
-  set = 'octicon',
-  ['typst-cache'] = '.quarto/iconify-svg',
-}
-
---- Whether the document configuration has already been checked this render.
---- The check lives here rather than in the companion filter because that
---- filter is opt-in (`filters: [iconify]`), while a shortcode always runs
---- when there is an icon to render.
---- @type boolean
-local options_validated = false
-
---- The document configuration resolved against `_schema.yml`, holding the
---- `provided`, `merged` and `defaults` tables. Nil until the first shortcode
---- runs, and left nil when there is no readable schema.
---- @type table|nil
-local resolved_options = nil
+--- The schema check, built once and reused by every shortcode call. It reads
+--- `_schema.yml` on the way in, checks the document configuration once, and
+--- checks each call against the entry that describes it.
+---
+--- The validator is injected rather than required by the check module, so the
+--- two vendored sources stay independent of where the other was placed.
+---
+--- The check runs from here rather than from the companion filter because that
+--- filter is opt-in (`filters: [iconify]`), while a shortcode always runs when
+--- there is an icon to render.
+---
+--- A schema that cannot be read is reported by the module as an error and the
+--- render carries on: a configuration file must not stop a document.
+local checker = check.new(schema, EXTENSION_NAME)
 
 --- Per-key deprecation warning tracker. Each deprecated metadata key warns
 --- at least once per render rather than once total. The companion filter
@@ -304,150 +287,6 @@ local function recover_kwargs(args, kwargs)
   return positional
 end
 
---- Load `_schema.yml` once per render.
---- @return table|nil The parsed schema, or nil when it could not be read
-local function load_extension_schema()
-  if not schema_loaded then
-    schema_loaded = true
-    local loaded, err = schema.load_schema(quarto.utils.resolve_path('_schema.yml'))
-    if err then
-      log.log_error(EXTENSION_NAME, err)
-    else
-      extension_schema = loaded
-    end
-  end
-  return extension_schema
-end
-
---- Flatten a shortcode's named options to plain strings for validation.
---- Every value is read through `attr_value`, so a quoted and an unquoted
---- value are checked as the same thing.
---- @param kwargs table<string, any> Key-value options for the icon
---- @return table<string, string>
-local function plain_kwargs(kwargs)
-  --- @type table<string, string>
-  local plain = {}
-  for key in pairs(kwargs) do
-    plain[tostring(key)] = attr_value(kwargs, key)
-  end
-  return plain
-end
-
---- Check `extensions.iconify` against `_schema.yml` once per render, and keep
---- what it resolves. `_schema.yml` holds every default this extension applies,
---- so the values it produces are read back here rather than restated in Lua.
----
---- Three tables are kept, because they answer different questions:
----   provided  what the document actually set, which is the only way to tell
----             a deliberate `false` or `0` from an absent key,
----   merged    the same values with coercion and defaults applied,
----   defaults  the schema defaults on their own, from a pass over an empty
----             table, used as the last resort in `document_option`.
---- @param meta table<string, any> Document metadata
---- @return table|nil The resolved tables, or nil when there is no schema
-local function resolve_document_options(meta)
-  if resolved_options ~= nil then
-    return resolved_options
-  end
-  if options_validated then
-    return nil
-  end
-  options_validated = true
-
-  --- @type table|nil
-  local loaded = load_extension_schema()
-  if loaded == nil or next(loaded.options) == nil then return nil end
-
-  --- @type table<string, any>
-  local provided = schema.extract_meta_options(meta, EXTENSION_NAME)
-  local valid, errors, warnings, merged = schema.validate(provided, loaded.options)
-
-  for _, message in ipairs(warnings) do
-    log.log_warning(EXTENSION_NAME, message)
-  end
-  if not valid then
-    for _, message in ipairs(errors) do
-      log.log_error(EXTENSION_NAME, message)
-    end
-  end
-
-  --- Validating an empty configuration yields the declared defaults alone.
-  local _, _, _, defaults = schema.validate({}, loaded.options, { unknown = 'ignore' })
-
-  resolved_options = { provided = provided, merged = merged, defaults = defaults }
-  return resolved_options
-end
-
---- Check one shortcode call against its entry in `_schema.yml` and report
---- whatever it finds. This reports only; nothing about the rendered icon
---- changes, so an unrecognised attribute is surfaced rather than dropped.
---- @param name string Shortcode name, 'iconify' or 'quarto'
---- @param args table<integer, any> Positional arguments
---- @param kwargs table<string, any> Key-value options for the icon
---- @return nil
-local function validate_call(name, args, kwargs)
-  --- @type table|nil
-  local loaded = load_extension_schema()
-  if loaded == nil then return end
-
-  --- @type table|nil
-  local entry = loaded.shortcodes and loaded.shortcodes[name]
-  if entry == nil then return end
-
-  --- @type table<integer, string>
-  local positional = {}
-  for index, value in ipairs(args) do
-    positional[index] = str.stringify(value)
-  end
-
-  local _, errors, warnings = schema.validate_shortcode(
-    name, positional, plain_kwargs(kwargs), entry)
-
-  -- Reported as warnings, not errors: the rendered icon never changes because
-  -- of a schema mismatch on an attribute, so this is advice rather than a
-  -- failure. An unrecognised value is still handled by the code that reads it.
-  for _, message in ipairs(warnings) do
-    log.log_warning(EXTENSION_NAME, message)
-  end
-
-  -- A required argument that is absent is the one case the rule above does not
-  -- cover: without it there is no icon, so the output does change. The check
-  -- is made here rather than read out of the validator's findings because the
-  -- validator reports a nested argument fault under one `arguments` entry,
-  -- which cannot tell a missing argument from a malformed one.
-  --- @type table<integer, table>
-  local missing = {}
-  for index, argument in ipairs(entry.arguments or {}) do
-    if argument.required == true and str.is_empty(positional[index]) then
-      missing[#missing + 1] = argument
-    end
-  end
-
-  if #missing > 0 then
-    -- The only message about the missing argument: the schema's own `required`
-    -- wording says the same thing, and reporting both would state one fault
-    -- twice at two severities. Attribute warnings above still stand, and every
-    -- other finding about this call is secondary to there being no icon.
-    for _, argument in ipairs(missing) do
-      --- The example comes from the schema so that each shortcode carries its
-      --- own, rather than this message naming one shortcode for all of them.
-      --- @type string
-      local advice = ''
-      local example = type(argument.examples) == 'table' and argument.examples[1] or nil
-      if example ~= nil then
-        advice = string.format(' For example: {{< %s %s >}}.', name, tostring(example))
-      end
-      log.log_error(EXTENSION_NAME, string.format(
-        'The "%s" shortcode needs its "%s" argument.%s', name, argument.name, advice))
-    end
-    return
-  end
-
-  for _, message in ipairs(errors) do
-    log.log_warning(EXTENSION_NAME, message)
-  end
-end
-
 --- Render a resolved option for the string contract every caller expects.
 --- A schema `inline: true` therefore reads as "true", which is what
 --- `meta_mod.get_metadata_value` produces for the same value in metadata.
@@ -475,12 +314,19 @@ end
 --- Presence is tested with `~= nil` rather than truthiness, so a deliberate
 --- `inline: false` or `typst-cache-max-age: 0` is honoured instead of being
 --- read as an absent key and replaced by its own default.
+---
+--- With no readable schema there is no tier left to fall back to, so the value
+--- is empty. The module has already reported that as an error, and the author
+--- has to restore the file rather than read a default the extension invented.
 --- @param key string The option name to retrieve
 --- @param meta table<string, any> Document metadata table
 --- @return string The option value as a string
 local function document_option(key, meta)
-  --- @type table|nil
-  local options = resolve_document_options(meta)
+  --- The second return holds the `provided`, `merged` and `defaults` tables,
+  --- and is nil when there is no readable schema. They belong to the checker
+  --- and are read, never written to. The first return is a copy of the
+  --- defaults, which `options.defaults` already answers for.
+  local _, options = checker:options(meta)
 
   if options ~= nil and options.provided[key] ~= nil then
     return option_to_string(options.merged[key])
@@ -495,7 +341,7 @@ local function document_option(key, meta)
     return option_to_string(options.defaults[key])
   end
 
-  return SCHEMA_UNAVAILABLE[key] or ''
+  return ''
 end
 
 --- Get an iconify option from arguments or metadata.
@@ -521,13 +367,12 @@ end
 --- @param meta table<string, any> Document metadata
 --- @return table<string, string>
 local function typst_cache_options(meta)
-  --- @type table|nil
-  local options = resolve_document_options(meta)
+  local _, options = checker:options(meta)
   return {
     cache_dir = document_option('typst-cache', meta),
     cache_fallback = options
       and option_to_string(options.defaults['typst-cache'])
-      or SCHEMA_UNAVAILABLE['typst-cache'],
+      or '',
     max_age_days = document_option('typst-cache-max-age', meta),
     max_entries = document_option('typst-cache-max-entries', meta),
   }
@@ -630,7 +475,7 @@ local function render_icon(args, kwargs, meta)
   -- the same way for every output format rather than only the two that render
   -- something. An empty first argument counts as no icon, which is what the
   -- schema's `required` check already decided, so the two agree.
-  -- `validate_call` has reported this to the author; there is nothing to add
+  -- The schema check has reported this to the author; there is nothing to add
   -- here beyond not reading a first argument that is not there.
   if #args == 0 or str.is_empty(str.stringify(args[1])) then
     return pandoc.Null()
@@ -823,9 +668,9 @@ end
 --- @param meta table<string, any> Document metadata
 --- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
 local function iconify(args, kwargs, meta)
-  resolve_document_options(meta)
+  checker:options(meta)
   args = recover_kwargs(args, kwargs)
-  validate_call('iconify', args, kwargs)
+  checker:call('iconify', args, kwargs)
   return render_icon(args, kwargs, meta)
 end
 
@@ -839,9 +684,9 @@ local function iconify_quarto(args, kwargs, meta)
   local quarto_args = { 'simple-icons:quarto' }
   --- @type table<string, any>
   local quarto_kwargs = kwargs or {}
-  resolve_document_options(meta)
+  checker:options(meta)
   recover_kwargs(args, quarto_kwargs)
-  validate_call('quarto', {}, quarto_kwargs)
+  checker:call('quarto', {}, quarto_kwargs)
   -- A decorative icon carries neither, and setting them here would re-introduce
   -- exactly what `aria-hidden` removes.
   if not is_decorative(quarto_kwargs, false) then


### PR DESCRIPTION
This extension had the runtime schema check written by hand.
The same wiring now comes from `schema-check.lua`, published in `quarto-lua-modules` 2.1.0.

It is a rename, not a rewrite.
`Checker:options` returns the resolved tables as its second value, `nil` in exactly the cases `resolve_document_options` returned `nil`, so `document_option` keeps its three tier order and its `~= nil` presence test.

The same probe document renders the same three messages before and after, and `diff` reports no difference.
The suite is 22 cases, 0 failed, one more than before, because the conformance cases are generated from the manifest.
Deleting the vendored module fails 9 cases, and changing one byte inside a comment fails the digest check alone, so the new case can see what it covers.

Two things change, both only when `_schema.yml` cannot be read.
`SCHEMA_UNAVAILABLE` is deleted, as the design requires, so `set` and `typst-cache` resolve to the empty string rather than to `octicon` and `.quarto/iconify-svg`; `_modules/typst.lua` then reports that no cache directory is available and returns early, so nothing raises and the render still exits 0.
And `check.new` reads the schema at file scope where the old code read it lazily, so an unreadable schema is reported for documents that use no shortcode, where it previously said nothing.

`logging.lua`, `metadata.lua` and `string.lua` move to 2.1.0, each changing only its `@version` banner.
`schema-check.lua` is new, and the `quarto-wizard` source stays at 3.4.0.

No changelog entry, because nothing user facing changes.
