### PR TITLE
docs: record the move to the shared schema check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Take the runtime schema check from the shared `schema-check.lua` module instead of the copy written in this extension. The check reports the same faults as before. (#91)
+
 ## 4.2.0 (2026-09-06)
 
 ### New Features


### PR DESCRIPTION
#91 changed the extension and left no changelog entry, so the pending release would have written no section for it. This records it.